### PR TITLE
fixing typos in doc

### DIFF
--- a/doc/CoCoALib-tasks/tasks.xml
+++ b/doc/CoCoALib-tasks/tasks.xml
@@ -92,7 +92,7 @@ Time est.: 1 week.
   <compl-date>0000-00-00</compl-date>
   <description>
 The homomorphism R[x,y,z] into R[x][y][z] is, mathematically speaking,
-      quite canonical, and also the viceversa.
+      quite canonical, and also the vice-versa.
 We should make this kind of homomorphisms easier to define (automatically?).
 Even though intuitively it looks quite obvious, it might be quite
       tedious to define it properly (e.g. we should probably forbid
@@ -636,7 +636,7 @@ Time est.: 1+ weeks.
   <compl-date>0000-00-00</compl-date>
   <description>
 It appears it can be useful to have a (template?) class for
-"Homogenous lists", i.e. vectors (?) of RingElems/PPMonoidElems having
+"Homogeneous lists", i.e. vectors (?) of RingElems/PPMonoidElems having
 the same owner.  It should be reference counted.
 It would be quite useful for the generators of an ideal: to avoid
 making copies, to guarantee that all elements are in the same ring.
@@ -1026,7 +1026,7 @@ Time est: 2-3 days.
 Right now only gradings with non-negative entries are allowed
 (because only ordering matrices with non-negative entries are allowed)
 Design how to deal with negative entries.
-Tiem est: ???
+Time est: ???
   </description>
 </task>
 
@@ -1181,7 +1181,7 @@ The real problem is that BOOST is huge.
 Review of the requirements for the new interactive language
 and how they interact.  The aim is to produce a report which analyses the various compromises
 and then indicates a final choice to proceed with for the production of a parser.  All decisions
-should be justfied so that a later reconsideration could be effected cheaply.  Time est.: 3-4 weeks.
+should be justified so that a later reconsideration could be effected cheaply.  Time est.: 3-4 weeks.
   </description>
 </task>
 
@@ -1238,7 +1238,7 @@ CoCoA-4.  Time est.: 1-2 weeks.
   <lastnews-date>2011-01</lastnews-date>
   <compl-date>0000-00-00</compl-date>
   <description>
-As a useful particular case of Homogenous lists 
+As a useful particular case of Homogeneous lists 
 <a href="#Descr:HomogList">(task)</a>
 We have a prototype in RingElemVector:
 reference counted (copy on write) vector of RingElems in the same
@@ -2128,7 +2128,7 @@ There are some basic arithmetic operations too.
 <authors>Abbott</authors>
 <compl-date>2009-07-02</compl-date>
 <description>
-Varius functions in the recent NumTheory file have been improved: <i>e.g.</i>
+Various functions in the recent NumTheory file have been improved: <i>e.g.</i>
 better
 interface, fewer bugs, clearer documentation.  Thanks to the participants of the recent CoCoA
 School in Barcelona whose opinions help answer some philosophical design questions.
@@ -2171,7 +2171,7 @@ The code should also work correctly on both 32 and 64 bit computers (but in fact
 There is now a global option for specifying whether elements of a
 quotient of ZZ are printed as least non-negative residues or as
 least magnitude residues.  The default is least magnitude (a change
-from the previous deault behaviour).  The residues are now always
+from the previous default behaviour).  The residues are now always
 printed without brackets -- previously brackets were used in some
 cases and not in others.
 </description>
@@ -2338,7 +2338,7 @@ done by a single implementation of each underlying algorithm.
 <compl-date>2008-11-24</compl-date>
 <description>
 The preprocessing algorithms are now rational, so give exact results (rather
-than the rational aproximations produced when all input data were converted
+than the rational approximations produced when all input data were converted
 into <code>double</code>s).  The speed of computation remains essentially unchanged.
 </description>
 </task>
@@ -2371,7 +2371,7 @@ To help non-english speakers, each error should
 produce an alphanumeric key/code which can be used to search in a manual of errors.
 We want to create an "index" of all coded errors with a more verbose
 explanation.  Possibly it should also include some information about
-the most common occurences of a given error and some suggestions for
+the most common occurrences of a given error and some suggestions for
 debugging and/or fixing it.
 See <span class=file>CoCoAErrorCodes.html</span>:
 <a href="http://cocoa.dima.unige.it/cocoalib/CoCoAErrorCodes.html">CoCoA
@@ -2563,7 +2563,7 @@ single quotes.  Check other places too (e.g. manual).
 <authors>Bigatti</authors>
 <compl-date>2007-09-25</compl-date>
 <description>
-The contructor for <span class=class>ServerOpBase</span> requires a
+The constructor for <span class=class>ServerOpBase</span> requires a
 <span class=class>LibraryInfo</span>.
 This way the server can print all libraries which have been linked in
 (or the list of all available operations with the library they are

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -235,7 +235,7 @@ veryclean-subdirs:
 # Summary: now redirect stderr into log file when running latex
 #
 # Revision 1.34  2017/11/16 14:18:46  abbott
-# Summary: Added new feature: builting alldoc also creates examples/index.html
+# Summary: Added new feature: building alldoc also creates examples/index.html
 #
 # Revision 1.33  2017/02/14 17:06:28  abbott
 # Summary: Updated clean/veryclean targets in all Makefiles
@@ -276,7 +276,7 @@ veryclean-subdirs:
 #
 # Revision 1.22  2011/09/23 13:28:21  abbott
 # Corrected unified command script for making CoCoALib.pdf
-# (removed some "cd" comands which are no longer needed).
+# (removed some "cd" commands which are no longer needed).
 #
 # Revision 1.21  2011/09/22 16:22:29  abbott
 # Minor correction: the CoCoALib.pdf rule is now a single shell script.

--- a/doc/txt/00INTRODUCTION.txt
+++ b/doc/txt/00INTRODUCTION.txt
@@ -107,7 +107,7 @@ The source for this documentation is in the CoCoALib directory ``doc/txt/``, and
 converted into html (``doc/html/``) and LaTeX (``doc/tex/``) using
 [``txt2tags`` http://txt2tags.sourceforge.net/].
 
-A template file fo adding to this documentation and some basic
+A template file for adding to this documentation and some basic
 instructions for [``txt2tags`` http://txt2tags.sourceforge.net/] are
 in the file [doc/txt/empty.txt empty.html].
 

--- a/doc/txt/BuiltInFunctions.txt
+++ b/doc/txt/BuiltInFunctions.txt
@@ -176,8 +176,8 @@ END_STD_BUILTIN_FUNCTION
 == Maintainer documentation ==
 %======================================================================
 
-*For overloaded functions explicitely*:
-Explicitely define all cases and make an extra default case
+*For overloaded functions explicitly*:
+Explicitly define all cases and make an extra default case
 for safety (gives protection in development when one type has been forgotten)
 ```
 DECLARE_STD_BUILTIN_FUNCTION(LT, 1) {

--- a/doc/txt/DistrMPolyInlPP.txt
+++ b/doc/txt/DistrMPolyInlPP.txt
@@ -15,7 +15,7 @@ be considering using this class -- use a polynomial ring instead.  That
 way you will gain ease of use and safety with only a small performance
 penalty.
 
-This class should be seen and used only by CoCoA library implementors;
+This class should be seen and used only by CoCoA library implementers;
 normal users should use the polynomial rings (which internally may well
 use DMPIs to represent their elements).
 

--- a/doc/txt/DynamicBitset.txt
+++ b/doc/txt/DynamicBitset.txt
@@ -128,7 +128,7 @@ a vector with 2 ``BitBlock``s and will have 4 unused bits)
 === boost? ===
 This class is needed because C++ ``bitset`` length has to be fixed at
 compile time.  There is a class in boost named ``dynamic_bitset``:
-if/when we decide CoCoALib inlude boost ``DynamicBitset`` will just
+if/when we decide CoCoALib include boost ``DynamicBitset`` will just
 call the boost implementation.
 
 === Stretchable? ===
@@ -146,5 +146,5 @@ to forbid it, so we might make it available.
 - moved definition of class ``facet`` from ``TmpIsTree`` into
   ``DynamicBitset.H,C`` (and renamed).
   Rearranged and changed names for similarity with bitsets in STL and
-  boost.  Stuctured in //safe// or //fast// functions according to
+  boost.  Structured in //safe// or //fast// functions according to
   coding conventions.  Test and example.

--- a/doc/txt/ExternalLibs-MathSAT.txt
+++ b/doc/txt/ExternalLibs-MathSAT.txt
@@ -10,7 +10,7 @@
 
 **MathSAT** is a Satisfiability modulo theories (SMT) solver.
 **MathSAT** is free software.
-The joint reasearch between CoCoA and MathSAT has been supported by
+The joint research between CoCoA and MathSAT has been supported by
 European Union's Horizon 2020 research and innovation programme 
 under grant agreement No H2020-FETOPEN-2015-CSA 712689:
 [**SC-square** website http://www.sc-square.org/]

--- a/doc/txt/ExternalLibs-Normaliz.txt
+++ b/doc/txt/ExternalLibs-Normaliz.txt
@@ -27,7 +27,7 @@ moment look at the examples for available functions on
 
 Download and compile **Normaliz** following the instructions from the website.
 
-Altenatively, you can download the sources from Github:
+Alternatively, you can download the sources from Github:
 First time
 ``` git clone https://github.com/Normaliz/Normaliz.git
 Update (from the Normaliz git folder)
@@ -182,7 +182,7 @@ g++  -I /Users/bigatti/0.99/gmp-6.1.0/ -L/Users/bigatti/0.99/gmp-6.1.0/.libs -lg
 == Bugs, shortcomings and other ideas ==
 %======================================================================
 
-We are still updating CoCoALib configuraton to use properly installed
+We are still updating CoCoALib configuration to use properly installed
 external libs.
 
 

--- a/doc/txt/ExternalLibs.txt
+++ b/doc/txt/ExternalLibs.txt
@@ -38,7 +38,7 @@ The ``ExternalLibInfo`` struct contains 3 fields (all have type ``std::string``)
 
 The implementation is not so pretty: it depends on the preprocessor
 flags set in the file ``PREPROCESS_DEFNS.H``.  The library name is
-the name I usually use when refering to the library.  The version
+the name I usually use when referring to the library.  The version
 number is whatever the library makes available (otherwise just the
 string "UNKNOWN").  The URL was typed in by hand.
 

--- a/doc/txt/GlobalManager.txt
+++ b/doc/txt/GlobalManager.txt
@@ -49,7 +49,7 @@ argument is used to specify the global settings, namely
 + the printing convention for elements of rings of the form ZZ/m, //viz.// least non-negative residues or least magnitude (symmetric) residues.
 +
 
-The current defaults are to use the system memory mananger and symmetric residues.
+The current defaults are to use the system memory manager and symmetric residues.
 
 
 ==== Specifying the memory manager for BigInt values ====

--- a/doc/txt/INSTALL.txt
+++ b/doc/txt/INSTALL.txt
@@ -87,7 +87,7 @@ In most cases the following two commands will suffice:
 This compiles CoCoALib as before (incl. tests & examples).
 It also compiles ``CoCoAInterpreter`` (in ``src/CoCoA-5``), and
 runs all the CoCoA-5 tests.  To run CoCoA-5 it is best to use
-the lauch script ``cocoa5`` (which is in ``src/CoCoA-5``).
+the launch script ``cocoa5`` (which is in ``src/CoCoA-5``).
 
 
 === Compilation of CoCoA-5 with GUI ===

--- a/doc/txt/JBMill.txt
+++ b/doc/txt/JBMill.txt
@@ -71,7 +71,7 @@ In the following let ``elem`` be a ``RingElem``.
 The basic datastructures to deal with Janet basis are implemented in ``JBDatastructure.C``. Everything of the following lives in the namespace ``CoCoA::Involutive``.
 ===JanetDatastructure===
 ====JanetTriple====
-The ``JanetTriple`` is nothing else than a polynomial with some extra informations.
+The ``JanetTriple`` is nothing else than a polynomial with some extra information.
 In addition to the polynomial ``myPolynom`` it has a data member ``myAncestor`` which is usually the LPP of ``myPolynom`` and the already prolonged variables (``myAlreadyProlongedVars``). If the ``JanetTriple`` arises from a prolongation ``x_i * myP^\prime`` the ancestor is the LPP of ``myP^\prime``.
 
 ====JanetNodeBase, JanetLeafNodeImpl, JanetInternalNodeImpl, JanetHandle, JanetTree====
@@ -102,7 +102,7 @@ But for computing a Janet basis we do not use this class for efficiency reasons.
 ====JanetIterator====
 The task of ``JanetIterator`` is to offer a way to navigate through the ``JanetTree``.
 Basically the ``JanetIterator`` consists of a pointer to the specific ``JanetTree``, pointer to the current in the tree and an iterator to a specific position in this list.
-The ``JanetIterator`` provides access (if possible) to the underlying ``JanetTriple``, provides the possibility to move forward in the tree, provides some informations of the current position in the tree and provides the functionality to add a new node in the ``JanetTree`` behind the current position.
+The ``JanetIterator`` provides access (if possible) to the underlying ``JanetTriple``, provides the possibility to move forward in the tree, provides some information of the current position in the tree and provides the functionality to add a new node in the ``JanetTree`` behind the current position.
 For knowing the way from the beginning of the tree to the current position it consists of a vector of longs which stores the specific degrees and the current variable.
 
 

--- a/doc/txt/MorseGraph.txt
+++ b/doc/txt/MorseGraph.txt
@@ -37,7 +37,7 @@ Now we assume that ``mill`` contains a homogeneous ideal and ``col`` and ``row``
 == Maintainer documentation for TmpMorseGraph.C, TmpMorseBetti.C, TmpMorseResolution.C, TmpPartialMorseBetti.C TmpMorseElement.C, TmpMorsePaths.C, TmpResolutionMinimization.C ==
 %======================================================================
 
-For computing free resolutions and graded Betti diagramms with a Janet basis we using algebraic discrete Morse theory.
+For computing free resolutions and graded Betti diagrams with a Janet basis we using algebraic discrete Morse theory.
 (More information about the mathematical background the user can find in "On the free resolution induced by a Pommaret basis").
 
 === MorseElement and JBElem ===
@@ -86,11 +86,11 @@ The implementation of ``MorseBetti`` and ``MorseResolution`` is quite similar.
 They compute and minimize the MorseGraph, but the ``MorseBetti`` class only computes the part of the graph where all edges have only a constant value.
 For further information look at the cited paper or at the inline documentation.
 Another difference between ``MorseBetti`` and ``MorseResolution`` is the expected output.
-``MorseBetti`` computes the graded betti diagram of an ideal. The betti diagramm is represented by ``matrix``.
+``MorseBetti`` computes the graded betti diagram of an ideal. The betti diagram is represented by ``matrix``.
 ``MorseResolution`` computes a graded free resolution of an ideal. The resolution is represented by ``vector<matrix>``.
 
 === PartialMorseBetti ===
-We use this class to compute a single Betti column or Betti number. It is a child class of ``MorseBetti``. The algorithms to compute these partial datas are nearly the same as in the class ``MorseBetti``. The only difference are the restriction to one column or only one number. For more informations take a look at the inline documentation.
+We use this class to compute a single Betti column or Betti number. It is a child class of ``MorseBetti``. The algorithms to compute this partial data are nearly the same as in the class ``MorseBetti``. The only difference are the restriction to one column or only one number. For more information, take a look at the inline documentation.
 
 === ResolutionMinimization ===
 

--- a/doc/txt/OpenMath.txt
+++ b/doc/txt/OpenMath.txt
@@ -44,7 +44,7 @@ of ``operator<<`` cast to either ``long`` or ``unsigned long``.
 Use ``boost::shared_ptr`` instead of [[SmartPtrIRC]]?
 
 Documentation woefully incomplete.  Actually the whole implementation needs a
-thorough revision, perhaps in collaboration with some others who are attemtping
+thorough revision, perhaps in collaboration with some others who are attempting
 to implement OpenMath.
 
 Code written hastily, so incomplete, largely untested, does not follow the

--- a/doc/txt/PBMill.txt
+++ b/doc/txt/PBMill.txt
@@ -81,7 +81,7 @@ The Pommaret basis is always a Janet basis, too. Therefore the datastructures fo
 This file defines all necessary things for dealing with Pommaret bases.
 ====PBMill====
 
-This class has as base class ``JBMill``. It does not introduce new data members, because the representation of a Pommaret basis is the same than for a Janet basis. The main differnce between these to classes is that ``PBMill`` only accept generating sets in delta-regular coordinates. In addition to that it implements some methods which are only appliccable when we have a Pommaret basis.
+This class has as base class ``JBMill``. It does not introduce new data members, because the representation of a Pommaret basis is the same than for a Janet basis. The main difference between these two classes is that ``PBMill`` only accept generating sets in delta-regular coordinates. In addition to that it implements some methods which are only appliccable when we have a Pommaret basis.
 
 ====PBMill::Builder====
 
@@ -94,19 +94,19 @@ This class is purley virtual. The real implementation is in the subclasses.
 To construct a ``PBMill`` out of the builder object the user can call a constructor of ``PBMill`` with a configured builder object.
 
 ====PBMill::Converter====
-This class is a subclass of ``PBMill::Builder``. It trys convert a ``JBMill`` direclty to a ``PBMill``, without changing coordinates.
+This class is a subclass of ``PBMill::Builder``. It tries to convert a ``JBMill`` directly to a ``PBMill``, without changing coordinates.
 
 ====PBMill::Transformator====
 This class is a subclass of ``PBMill::Builder``. It is again a purley virtual class. It acts as base class for all Builder-classes which applying coordinate transformations to get a specific stability position.
 
 ====PBMill::DeltaRegularTransformator====
-This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with delta-regular coordinates. The user can choose between four different strategies which are definied in the enum ``PBMill::DeltaRegularTransformator::StrategyFlag``.
+This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with delta-regular coordinates. The user can choose between four different strategies which are defined in the enum ``PBMill::DeltaRegularTransformator::StrategyFlag``.
 
 ====PBMill::StableLTITransformator====
-This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with stable leading ideal. The user can choose between two different strategies which are definied in the enum ``PBMill::StableLTITransformator::StrategyFlag``.
+This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with stable leading ideal. The user can choose between two different strategies which are defined in the enum ``PBMill::StableLTITransformator::StrategyFlag``.
 
 ====PBMill::StronglyStableLTITransformator====
-This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with strongly stable leading ideal. The user can choose between two different strategies which are definied in the enum ``PBMill::StronglyStableLTITransformator::StrategyFlag``.
+This class is a subclass of ``PBMill::Transformator``. It transforms a Janet basis to a Pommaret basis with strongly stable leading ideal. The user can choose between two different strategies which are defined in the enum ``PBMill::StronglyStableLTITransformator::StrategyFlag``.
 
 ===StabilityAlgorithm===
 
@@ -140,7 +140,7 @@ The implementation is almost the same than ``StableLTI``. The only difference is
 This class is a subclass of ``StronglyStableLTI``. The implementation is almost the same than ``StronglyStableLTI``. The only difference is the method ``DoComputeImage``. This class also computes transformation like x_i -> x_i + x_j_1 + ... + x_j_s.
 
 ====Problems&Ideas related to StabilityAlgorithm====
-If we could make ``StableLTI`` to a subclass of ``DeltaRegular`` it would be quite nice, because this would represent the mathematical hierachy as well.
+If we could make ``StableLTI`` to a subclass of ``DeltaRegular`` it would be quite nice, because this would represent the mathematical hierarchy as well.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/doc/txt/PPMonoid.txt
+++ b/doc/txt/PPMonoid.txt
@@ -439,7 +439,7 @@ owner).
 The constructors for ``PPMonoidElemRawPtr`` and ``PPMonoidElemConstRawPtr``
 are ``explicit`` to avoid potentially risky automatic conversion of any
 old pointer into one of these types.  The naked pointer may be accessed
-via the member functions ``myRawPtr``.  Only implementors of new PP
+via the member functions ``myRawPtr``.  Only implementers of new PP
 monoid classes are likely to find these two opaque pointer classes useful.
 
 

--- a/doc/txt/QuasiPoly.txt
+++ b/doc/txt/QuasiPoly.txt
@@ -23,7 +23,7 @@ A quasi-polynomial is a list ``F_1,...,F_r`` of ``r`` univariate polynomials
 === Constructors and pseudo-constructors ===[constructors]
 %----------------------------------------------------------------------
 
-- ``QuasiPoly(L)`` creates the quasi-polynomial whose consituents are the entries of ``L``
+- ``QuasiPoly(L)`` creates the quasi-polynomial whose constituents are the entries of ``L``
 (of type ``std::vector<RingElem>``)
 
 

--- a/doc/txt/RegisterServerOps.txt
+++ b/doc/txt/RegisterServerOps.txt
@@ -80,7 +80,7 @@ or make a dedicated file ``MyRegisterServerOps.H``
 (see, for example, ``src/server/RegisterServerOpsFrobby.H``)
 and include it in ``src/server/CoCoAServer.C``
 
-== Mantainer documentation ==
+== Maintainer documentation ==
 %======================================================================
 
 How does this work?  When ``CoCoAServer.C`` is compiled the global

--- a/doc/txt/RingDistrMPolyInlPP.txt
+++ b/doc/txt/RingDistrMPolyInlPP.txt
@@ -45,7 +45,7 @@ See [[SparsePolyRing]] and [[PolyRing]] for operations.
 == Maintainer documentation ==
 %======================================================================
 
-Most of the real work is delegated to [[DistrMPolyInlPP]]; pratically all
+Most of the real work is delegated to [[DistrMPolyInlPP]]; practically all
 member fns forward to ``DistrMPolyInlPP``.
 
 Note that the ``PPM`` must be of type ``PPMonoidOv``!

--- a/doc/txt/RingElem.txt
+++ b/doc/txt/RingElem.txt
@@ -96,7 +96,7 @@ between ``RingElem``s will fail if they do not belong to the same ring
 
 ==== Assignment & Swapping ====
 
-Assigning an integer or rational to a ``RingElem`` wil automatically map
+Assigning an integer or rational to a ``RingElem`` will automatically map
 the value into the ring to which the ``RingElem`` belongs.
  | ``r = n;``     | map ``n`` into ``owner(r)`` and assign the result |
  | ``r = q;``     | map ``q`` into ``owner(r)`` and assign the result |
@@ -545,7 +545,7 @@ might find this section informative.
 ``RingElem``s are designed to be easy and pleasant to use, but this
 convenience has a price: a run-time performance penalty (and a memory
 space penalty too).
-Both penalities may be avoided by using //raw values// but at a
+Both penalties may be avoided by using //raw values// but at a
 considerable loss of programming convenience and safety.  You should
 consider using raw values only if you are desperate for speed; even
 so, performance gains may be only marginal except perhaps for

--- a/doc/txt/RingTwinFloat.txt
+++ b/doc/txt/RingTwinFloat.txt
@@ -95,7 +95,7 @@ Let ``RR`` be a ``RingTwinFloat`` and ``S`` any [[ring]]
 As usual the class ``RingTwinFloat`` is just a reference counting smart pointer
 to an object of type ``RingTwinFloatImpl`` (which is the one which really does
 the work).  The implementation of the smart pointer class ``RingTwinFloat`` is
-altogether straightfoward (just the same as any of the other smart
+altogether straightforward (just the same as any of the other smart
 pointer ring classes).
 
 === Philosophy ===

--- a/doc/txt/SmallFpImpl.txt
+++ b/doc/txt/SmallFpImpl.txt
@@ -48,7 +48,7 @@ The default export convention is ``SymmResidues`` (unless changed in the [[Globa
 the default convention is determined by the [[GlobalManager]].
 
 
-**Note** if the first argment is of type ``SmallPrime`` then the constructor
+**Note** if the first argument is of type ``SmallPrime`` then the constructor
 skips testing for primality.
 
 

--- a/doc/txt/SmartPtrIRC.txt
+++ b/doc/txt/SmartPtrIRC.txt
@@ -50,7 +50,7 @@ SECTION.
 
 **IMPORTANT NOTE**:
 it is highly advisable to have ``myRefCountZero()`` as the very last
-operation in every contructor of a class derived from
+operation in every constructor of a class derived from
 ``IntrusiveReferenceCount``, i.e. intended to be used with
 ``SmartPtrIRC``.
 

--- a/doc/txt/SugarDegree.txt
+++ b/doc/txt/SugarDegree.txt
@@ -9,7 +9,7 @@
 %======================================================================
 
 Abstract class for implementing several kinds of //sugar//:
-- homogenous case (= the degree)
+- homogeneous case (= the degree)
 - non graded case (using StdDeg)
 - graded case (using wdeg)
 - non graded case and saturating algorithm

--- a/doc/txt/assert.txt
+++ b/doc/txt/assert.txt
@@ -87,7 +87,7 @@ The following (simplified but real) code excerpt is mildly problematic:
 }
 ```
 When compiled without debugging (//i.e.// ``CoCoA_DEBUG`` is zero) the compiler
-(gcc-3) complains that the variable ``OK`` is unusued.  It does not appear
+(gcc-3) complains that the variable ``OK`` is unused.  It does not appear
 to be possible to make the macro "depend on its argument" in the
 non-debugging case without incurring the run-time cost of evaluating the
 argument (if the argument is just a variable the cost is negligible, but

--- a/doc/txt/convert.txt
+++ b/doc/txt/convert.txt
@@ -91,7 +91,7 @@ Conversion to C++ integral types other than (unsigned) int/long is not yet suppo
 Indeed the ``IsConvertible`` functions are a hotch potch, but how can it be done better?
 
 BOOST has ``numeric_cast`` which is like ``IntegerCast`` for built-in numerical types.
-Sooner or later we could pehaps use that?
+Sooner or later we could perhaps use that?
 
 
 Should conversion of ``BigRat`` to ``double`` ignore underflow, or should it fail?

--- a/doc/txt/factorization.txt
+++ b/doc/txt/factorization.txt
@@ -72,7 +72,7 @@ Let ``FactorInfo`` be of type ``factorization<T>``.  These are the operations av
 %======================================================================
 
 Being template code it's all in the header file.
-It's mostly fairly straightfoward.
+It's mostly fairly straightforward.
 
 The main point to note is that ``ourCheckNotZeroDiv`` and ``ourCheckNotUnit``
 need to be written by hand for each instantiation -- this is enforced by the

--- a/doc/txt/geobucket.txt
+++ b/doc/txt/geobucket.txt
@@ -99,7 +99,7 @@ A ``bucket`` represents a polynomial as a product of a polynomial and
 a coefficient, two ``RingElem`` respectivey in a [[SparsePolyRing]]
 ``P`` and ``CoeffRing(P)``.
 
-The coeffient factor is used for fast multiplication of a geobucket
+The coefficient factor is used for fast multiplication of a geobucket
 by a coefficient and it comes useful in the reduction process over
 a field of fraction of a GCD ring.
 

--- a/doc/txt/module.txt
+++ b/doc/txt/module.txt
@@ -17,7 +17,7 @@ together (analogously to the triple ``ring``, ``RingBase`` and ``RingElem``).
 
 The class ``module`` is a reference counting smart pointer to an object of
 type derived from ``ModuleBase``; all concrete types for representing modules
-are derived from ``ModuleBase``.  For a library implementor the class
+are derived from ``ModuleBase``.  For a library implementer the class
 ``ModuleBase`` defines the minimal interface which every concrete module
 class must offer; indeed the concrete class must be derived from
 ``ModuleBase``.

--- a/doc/txt/ring.txt
+++ b/doc/txt/ring.txt
@@ -182,7 +182,7 @@ urged to familiarize yourself with the maintainer documentation if you want
 to understand how and why rings are implemented as they are in the CoCoA
 library.
 
-The first decision to make when implementating a new ring class for
+The first decision to make when implementing a new ring class for
 CoCoALib is where to place it in the ring inheritance structure.  This
 inheritance structure is a (currently) tree with all concrete classes at
 the leaves, and all abstract classes being internal nodes.  Usually the new
@@ -276,7 +276,7 @@ implementation object, is defined as a data member of ``RingBase``.
 
 For the other classes see [[RingElem]].
 
-**NOTE** an earlier implemetation of rings memorized some ``RingHom``
+**NOTE** an earlier implementation of rings memorized some ``RingHom``
 values in data members of the ring object; this caused problems with
 circular reference counts, so was eliminated.
 


### PR DESCRIPTION
found using 

`codespell -L=strat,bringin,connexion,arithmetics,normale,ans doc/`