### PR TITLE
fix some typos in examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -297,7 +297,7 @@ $(COCOA_ROOT)/configuration/autoconf.mk:
 # Summary: Added new examples for C++: ex-c++-basic, ex-c++-arith, ex-c++-for-loop
 #
 # Revision 1.89  2017/02/08 17:00:22  abbott
-# Summary: Added new exmaples ex-ideal1 ex-ideal2 ex-IdealOfPoints
+# Summary: Added new examples ex-ideal1 ex-ideal2 ex-IdealOfPoints
 #
 # Revision 1.88  2017/01/19 16:53:13  abbott
 # Summary: Moved target CopyInfo so that target "default" is first; renamed loop variable from F to SrcFile

--- a/examples/ex-BenchmarkToolkit-xml.in
+++ b/examples/ex-BenchmarkToolkit-xml.in
@@ -1071,7 +1071,7 @@
             <Name>Chemequ</Name>
             <Description>\textbf{Title}: This polynomial system describes the equilibrium of the products of hydrocarbon combustion.</Description>
             <References>\begin{itemize}\item Keith Meintjes and Alexander P. Morgan:  'Chemical equilibrium systems as numerical test problems', ACM Toms, Vol 16, No 2, 143-151, 1990.\end{itemize}</References>
-            <Notes>Although the total degree equals 108, there are only 4 real and 12 complex solutions and an infinite number of solutions at infinity. A typographical error has occured in equation (2d), instead of $+ 4Ry5$, it should be a $- 4Ry5$. Applying m-homogenization straight to it renders $B = 56$. Simple linear reduction makes the total degree equal to 48. With m-homogenization, no better upper bound can then be computed. The constants are: $R = 10,  p = 40,  \sqrt{p} = 6.3246$</Notes>
+            <Notes>Although the total degree equals 108, there are only 4 real and 12 complex solutions and an infinite number of solutions at infinity. A typographical error has occurred in equation (2d), instead of $+ 4Ry5$, it should be a $- 4Ry5$. Applying m-homogenization straight to it renders $B = 56$. Simple linear reduction makes the total degree equal to 48. With m-homogenization, no better upper bound can then be computed. The constants are: $R = 10,  p = 40,  \sqrt{p} = 6.3246$</Notes>
             <Variables>x,y,z,w,u</Variables>
             <TagsList>DevRevLex, DegLex, Lex, chemequ, with_5_vars, easy_problem</TagsList>
             <TestEnvironment>rings_with_5_vars</TestEnvironment>
@@ -1259,7 +1259,7 @@
             <ID>cohn2</ID>
             <Name>Cohn2</Name>
             <Description>\textbf{Title}: Modular equations for special algebraic number fields</Description>
-            <References>\begin{itemize}\item From PoSSo test suite.\item Andre' Galligo and Carlo Traverso: 'Practical Determination of the dimension of an algebraic variety', in E. Kaltofen and S.M. Watt, Eds 'Computers and Mathematics', pages 46-52, 1989.\item H. Cohn: 'An explicit modular equation in two variables and Hilbert's Twelfth problem', Math. of Comp. 38, pp. 227-236, 1982.\item H. Cohn, J. Deutch: 'An explit modular equation in two variables for Q[$\sqrt{3}$]', Math. of Comp. 50, pp. 557-568, 1988. \end{itemize}</References>
+            <References>\begin{itemize}\item From PoSSo test suite.\item Andre' Galligo and Carlo Traverso: 'Practical Determination of the dimension of an algebraic variety', in E. Kaltofen and S.M. Watt, Eds 'Computers and Mathematics', pages 46-52, 1989.\item H. Cohn: 'An explicit modular equation in two variables and Hilbert's Twelfth problem', Math. of Comp. 38, pp. 227-236, 1982.\item H. Cohn, J. Deutch: 'An explicit modular equation in two variables for Q[$\sqrt{3}$]', Math. of Comp. 50, pp. 557-568, 1988. \end{itemize}</References>
             <Variables>x,y,z,w</Variables>
             <TagsList>DevRevLex, DegLex, Lex, cohn2, with_4_vars, easy_problem</TagsList>
             <TestEnvironment>rings_with_4_vars</TestEnvironment>
@@ -1334,8 +1334,8 @@
             <ID>cohn3</ID>
             <Name>Cohn3</Name>
             <Description>\textbf{Title}: Modular equations for special algebraic number fields</Description>
-            <References>\begin{itemize}\item From PoSSo test suite.\item Andre' Galligo and Carlo Traverso: 'Practical Determination of the dimension of an algebraic variety', in E. Kaltofen and S.M. Watt, Eds 'Computers and Mathematics', pages 46-52, 1989.\item H. Cohn: 'An explicit modular equation in two variables and Hilbert's Twelfth problem', Math. of Comp. 38, pp. 227-236, 1982.\item H. Cohn, J. Deutch: 'An explit modular equation in two variables for Q[$\sqrt{3}$]', Math. of Comp. 50, pp. 557-568, 1988. \end{itemize}</References>
-            <Notes>From the 213 solution paths, 110 converged to finite solutions.\\ There are eight highly singular solutons with zero components\\ that are probably not isolat</Notes>
+            <References>\begin{itemize}\item From PoSSo test suite.\item Andre' Galligo and Carlo Traverso: 'Practical Determination of the dimension of an algebraic variety', in E. Kaltofen and S.M. Watt, Eds 'Computers and Mathematics', pages 46-52, 1989.\item H. Cohn: 'An explicit modular equation in two variables and Hilbert's Twelfth problem', Math. of Comp. 38, pp. 227-236, 1982.\item H. Cohn, J. Deutch: 'An explicit modular equation in two variables for Q[$\sqrt{3}$]', Math. of Comp. 50, pp. 557-568, 1988. \end{itemize}</References>
+            <Notes>From the 213 solution paths, 110 converged to finite solutions.\\ There are eight highly singular solutions with zero components\\ that are probably not isolat</Notes>
             <Variables>x,y,z,w</Variables>
             <TagsList>DevRevLex, DegLex, Lex, cohn3, with_4_vars, easy_problem</TagsList>
             <TestEnvironment>rings_with_4_vars</TestEnvironment>
@@ -1431,7 +1431,7 @@
         <Example>
             <ID>comb3000</ID>
             <Name>Comb3000</Name>
-            <Description>\textbf{Title}: Model A combustion chemistry example for a temparature of 3000 degrees</Description>
+            <Description>\textbf{Title}: Model A combustion chemistry example for a temperature of 3000 degrees</Description>
             <References>\begin{itemize}\item A.P. Morgan: `Solving Polynomial Systems Using Continuation for Engineering and Scientific Problems', Prentice-Hall, Englewood Cliffs, N.J., 1987.\end{itemize}</References>
             <Notes>The system should be scaled properly.</Notes>
             <Variables>x,y,z,w,u,v,r,s,t,p</Variables>
@@ -1497,7 +1497,7 @@
         <Example>
             <ID>comb3000s</ID>
             <Name>Comb3000s</Name>
-            <Description>\textbf{Title}: Model A combustion chemistry example for a temparature of 3000 degrees</Description>
+            <Description>\textbf{Title}: Model A combustion chemistry example for a temperature of 3000 degrees</Description>
             <References>\begin{itemize}\item A.P. Morgan: `Solving Polynomial Systems Using Continuation for Engineering and Scientific Problems', Prentice-Hall, Englewood Cliffs, N.J., 1987.\end{itemize}</References>
             <Variables>x,y,z,w,u,v,r,s,t,p</Variables>
             <TagsList>DevRevLex, DegLex, Lex, comb3000s, with_10_vars, easy_problem</TagsList>

--- a/examples/ex-Janet1.C
+++ b/examples/ex-Janet1.C
@@ -14,7 +14,7 @@ const string ShortDescription =
   "In this file we explain how to compute the Janet Basis in CoCoA.  \n";
 
 const string LongDescription =
-  " We explain the function JanetBasis and show whicht options we can choose. \n";
+  " We explain the function JanetBasis and show which options we can choose. \n";
 //----------------------------------------------------------------------
 
 void output(vector<RingElem> vec)

--- a/examples/ex-Janet2.C
+++ b/examples/ex-Janet2.C
@@ -49,10 +49,10 @@ void program()
   Involutive::JBMill mill(Involutive::JBMill::Builder().setInput(cyclic4));
   cout << endl;
   cout << "Janet Basis is delta-regular (there exists a finite Pommaret Basis): " << mill.IamPommaretBasis() << endl;
-  cout << "Janet Basis is homogenous (Ideal is homogenous)" << mill.IamHomogenous() << endl;
+  cout << "Janet Basis is homogeneous (Ideal is homogeneous)" << mill.IamHomogenous() << endl;
   cout << "Janet Basis is monomial (Ideal is monomial)" << mill.IamMonomialIdeal() << endl;
   cout << endl;
-  cout << "-----nonmultiplicative variables of the Janet-Base of cylic 4 (easy way)" << endl;
+  cout << "-----nonmultiplicative variables of the Janet-Base of cyclic 4 (easy way)" << endl;
   mill.myPrintNonMultVar();
 
   cout << endl << endl ;

--- a/examples/ex-NumTheory3.C
+++ b/examples/ex-NumTheory3.C
@@ -12,7 +12,7 @@ const string ShortDescription =
   "whether a number is prime.  We compute many Goldbach representations. \n";
 
 const string LongDescription =
-  "This program tests how hard it is to find a \"Goldbach\" represetation \n"
+  "This program tests how hard it is to find a \"Goldbach\" representation \n"
   "of an integer; i.e. a sum of two primes.  It has to do many primality  \n"
   "tests, so it is faster to use a table than call IsPrime repeatedly.    \n";
 //----------------------------------------------------------------------

--- a/examples/ex-Pommaret2.C
+++ b/examples/ex-Pommaret2.C
@@ -33,7 +33,7 @@ void program()
   cout << ShortDescription << endl;
   cout << boolalpha << endl;
   ring Q = RingQQ();
-  cout <<"///////////////A homogenous ideal with a Pommaret basis//////////////////////////////////////////" << endl;
+  cout <<"///////////////A homogeneous ideal with a Pommaret basis//////////////////////////////////////////" << endl;
   SparsePolyRing polyRing6 = NewPolyRing(Q, SymbolRange("x",0,5));
   vector<RingElem> x = indets(polyRing6);
   vector<RingElem> polys;

--- a/examples/ex-QuotientBasis.C
+++ b/examples/ex-QuotientBasis.C
@@ -154,7 +154,7 @@ int main()
 // Some other minor cleaning.
 //
 // Revision 1.6  2006/11/27 13:22:23  cocoa
-// -- deteted unused #include file
+// -- detected unused #include file
 //
 // Revision 1.5  2006/11/21 14:35:13  cocoa
 // -- fixed/hacked a problem with bind2nd: what's the correct way to fix it?

--- a/examples/ex-RandomBool1.C
+++ b/examples/ex-RandomBool1.C
@@ -52,7 +52,7 @@ namespace CoCoA
     cout << "The coin came up heads " << count << " times -- this count should be about " << LowProb*NumIters << endl
          << endl
          << "The ""prob"" function uses on average about two random bits per call." << endl
-         << "The actual number of random bits used for ths trial is " << RndBool.myIndex() - StartIndex << endl
+         << "The actual number of random bits used for this trial is " << RndBool.myIndex() - StartIndex << endl
          << "We see that this value is indeed not far from " << 2*NumIters << endl
          << endl;
 

--- a/examples/ex-RingFp2.C
+++ b/examples/ex-RingFp2.C
@@ -11,7 +11,7 @@ const string ShortDescription =
   "When computing over a finite field normally it is best to use the\n"
   "function NewZZmod to create the field.  However, for the curious \n"
   "it is possible to create small prime finite fields stating the   \n"
-  "particular implemention method (there are 3 possibilities).      \n";
+  "particular implementation method (there are 3 possibilities).      \n";
 
 const string LongDescription =
   "This program compares the speeds of computing sums and products in   \n"

--- a/examples/ex-SmallFp3.C
+++ b/examples/ex-SmallFp3.C
@@ -46,7 +46,7 @@ namespace CoCoA
   FpElem InnerProd_SLOW(const SmallFpImpl& Fp, const vector<FpElem>& u, const vector<FpElem>& v)
   {
     const long n = len(u);
-    FpElem ans; // initally zero
+    FpElem ans; // initially zero
     for (long i=0; i < n; ++i)
       ans = Fp.myAdd(ans, Fp.myMul(u[i],v[i]));
     return ans;

--- a/examples/ex-c++-class.C
+++ b/examples/ex-c++-class.C
@@ -8,12 +8,12 @@ using namespace std;
 
 //----------------------------------------------------------------------
 const string ShortDescription =
-  "This is a (harder) example showing the implemention of a simple C++ class.\n"
+  "This is a (harder) example showing the implementation of a simple C++ class.\n"
   "It shows class definition, and use of an object of that class.            \n"
   "The class contains a general factorization of an integer.                 \n";
 
 const string LongDescription =
-  "This is a (harder) example showing the implemention of a simple C++ class.\n"
+  "This is a (harder) example showing the implementation of a simple C++ class.\n"
   "It shows class definition, and use of an object of that class.            \n"
   "The class contains a general factorization of an integer.  The class data \n"
   "members are `private' so their values can be seen or changed only by      \n"

--- a/examples/ex-c++-integers.C
+++ b/examples/ex-c++-integers.C
@@ -108,7 +108,7 @@ namespace CoCoA
     //     So 1/2 == 0.  Be careful!!
     
     // better_formula:  using brackets we instruct the compiler
-    //      to muliply first, then divide; the problem is that
+    //      to multiply first, then divide; the problem is that
     //      the multiplication may overflow even if the answer
     //      is small enough to fit into a long.
     //      C++ associativity rules mean that n*(n+1)/2 is interpreted
@@ -244,7 +244,7 @@ int main()
 // Summary: Improved example about pre-empting overflow
 //
 // Revision 1.3  2022/03/21 10:07:38  bigatti
-// Summary: suggested  n = 5000000000L; exlicitely
+// Summary: suggested  n = 5000000000L; explicitly
 //
 // Revision 1.2  2022/03/17 18:29:18  abbott
 // Summary: Better comments


### PR DESCRIPTION
found using

`codespell -L=strat,bringin,connexion,arithmetics,normale,ans,larg,alph,fith,fpt,nd,wit,theses,tre,thik,numer,dezember,ressize,fonctions examples/`