### PR TITLE
fix typos in configuration

### DIFF
--- a/configuration/boost-check-arch.sh
+++ b/configuration/boost-check-arch.sh
@@ -4,7 +4,7 @@
 # a program compiled with the GMP compilation flags.
 # We check just libboost_filesystem.a, and if that works OK
 # then we assume all the BOOST libs are fine too.
-# ASSUMES enviroment variables CXX and CXXFLAGS are set correctly.
+# ASSUMES environment variables CXX and CXXFLAGS are set correctly.
 
 SCRIPT_NAME=[[`basename "$0"`]]
 SCRIPT_DIR=`dirname "$0"`

--- a/configuration/boost-find-hdrs.sh
+++ b/configuration/boost-find-hdrs.sh
@@ -8,7 +8,7 @@
 # If several are found, it prints out the first one then exits with code 1
 # (used by "configure" in CoCoA root dir).
 
-# EXIT CODES: 0 = "found 1 boost insallation";  prints full path
+# EXIT CODES: 0 = "found 1 boost installation";  prints full path
 #             1 = "found several installations"; prints full path of one
 #             2 = "found no boost installation"
 

--- a/configuration/boost-find-lib.sh
+++ b/configuration/boost-find-lib.sh
@@ -2,7 +2,7 @@
 
 # This script looks for the necessary BOOST sub-libraries.
 # If found, it prints out two SHELL assignments (to be processed
-# using the eval commmand) to BOOST_LIB_DIR & BOOST_LDLIBS.
+# using the eval command) to BOOST_LIB_DIR & BOOST_LDLIBS.
 # It also creates symbolic links in $EXTLIB_5_DIR_FULL [var must be set]
 # If not, it prints out a warning and returns with exit code 1.
 

--- a/configuration/gmp-find-lib.sh
+++ b/configuration/gmp-find-lib.sh
@@ -10,7 +10,7 @@ SCRIPT_NAME=[[$(basename "$0")]]
 # If none is found, it prints out an error message (on stderr)
 # and returns with exit code 2.
 
-# EXIT CODES: 0 = "found 1 GMP insallation";  prints full path
+# EXIT CODES: 0 = "found 1 GMP installation";  prints full path
 #             1 = "found several installations"; prints full path of one
 #             2 = "found no GMP installation"
 


### PR DESCRIPTION
found using

`codespell -L=strat configuration/`