### PR TITLE
Remove redundant entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,7 @@ configuration/last-config-cmd
 include/CoCoA/library.H
 include/CoCoA/PREPROCESSOR_DEFNS.H
 lib/timestamp
-src/AlgebraicCore/Makefile_dependencies
-src/AlgebraicCore/TmpFactorDir/Makefile_dependencies
-src/AlgebraicCore/TmpFactorDir/linalg/Makefile_dependencies
-src/AlgebraicCore/TmpFactorDir/multivariate/Makefile_dependencies
-src/AlgebraicCore/TmpHilbertDir/Makefile_dependencies
 src/AlgebraicCore/leak_checker
-src/CoCoA-5/Makefile_dependencies
 src/CoCoA-5/CoCoAInterpreter
 src/CoCoA-5/check-version-defines
 src/CoCoA-5/**/*.Debug
@@ -62,8 +56,6 @@ src/CoCoA-5/C5Makefile
 src/CoCoA-5/C5.pro
 src/CoCoA-5/ui_*.h
 src/server/all
-src/server/Makefile_dependencies
-src/tests/Makefile_dependencies
 src/tests/*.cerr
 src/tests/*.cout
 src/tests/*found


### PR DESCRIPTION
This reverts a few changes from 740f9014824f8bd7bb160ff4e77b46b4b06b5186.
These entries are not really needed due to [this ignore](https://github.com/cocoa-official/CoCoALib/blob/b19c1df3fd689067a46d92cfff2a296330ab8a82/.gitignore#L31), which additionally matches temporary `Makefile_dependencies[.old/.new]` files