### PR TITLE
Add appropriate .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/AlgebraicCore/TmpLDP.C
+++ b/src/AlgebraicCore/TmpLDP.C
@@ -1418,7 +1418,7 @@ namespace CoCoA
           }
 	  else
           {
-            //AddToCornerAndUpdate(t, QBG, Alpha, S, J); ///non posso più usarla!!!
+            //AddToCornerAndUpdate(t, QBG, Alpha, S, J); ///non posso piÃ¹ usarla!!!
             sol=xbar;
 ///	      cout << endl;
 ///	      cout << endl << "Spostamento totale= " << convertVector(sol) << endl;
@@ -1456,7 +1456,7 @@ namespace CoCoA
 ///		  cout << " +" << d << "*" << QBAsPoly[i];
 ///		}
 ///	      cout << endl << endl;
-            //vedere se è almost vanishing
+            //vedere se Ã¨ almost vanishing
 ////??            double VV=Norm2Double(NewVectorGSL(NewRho));
             //cout << "||f(Xbar)|| = " << VV << endl;
             vector<RingElem> CoeffsF;

--- a/src/CoCoA-5/packages/experimental.cpkg5
+++ b/src/CoCoA-5/packages/experimental.cpkg5
@@ -416,17 +416,17 @@ EndDefine; -- Pres_Im_Hom_Mod
 -- (c) Pres_Ker_Hom_Mod.
 -- Input:(P^r, M, P^s, N, [w_1,...,w_r])
 -- Output:
--- (1) Se il Ker è non nullo:
+-- (1) Se il Ker Ã¨ non nullo:
 -- Record[Free_Mod_Ker := P^u,
 --              Quot_Ker := submodule(P^u,[(l_i1,...,l_iu) : i in {1,...,u'}])]
--- (2) Se il Ker è nullo: [].
+-- (2) Se il Ker Ã¨ nullo: [].
 
 Define Pres_Ker_Hom_Mod(Pr,M,Ps,N,L) // L = list of phi(e_i)
   -- Richiamo la  funzione Gens_Ker_Hom_Mod.
   Gens_Ker := gens(Gens_Ker_Hom_Mod(Pr,M,Ps,N,L).Preimage_Ker);
-  -- Caso in cui il Ker è nullo.
+  -- Caso in cui il Ker Ã¨ nullo.
   If Gens_Ker=[] Then Return []; EndIf;
-  -- Caso in cui il Ker è non nullo.
+  -- Caso in cui il Ker Ã¨ non nullo.
   P := RingOf(Pr);
   u := len(Gens_Ker);
   Pu := NewFreeModule(P,u);

--- a/src/CoCoA-5/tests/test-HomomorphismOps.cocoa5
+++ b/src/CoCoA-5/tests/test-HomomorphismOps.cocoa5
@@ -45,7 +45,7 @@ T0 := CpuTime();
 -- (3) Isomorfismo di K-algebre affini,
 -- avente come dominio e come codominio due anelli quoziente.
 
--- (4) Omomorfismo di K-algebre polinomiali, né iniettivo, né surgettivo.
+-- (4) Omomorfismo di K-algebre polinomiali, nÃ© iniettivo, nÃ© surgettivo.
 
 -- (5) Omomorfismo di K-algebre affini, surgettivo ma non iniettivo,
 -- avente come dominio un anello di polinomi e come codominio un anello
@@ -56,8 +56,8 @@ T0 := CpuTime();
 -- x+I1=[x] -----> a^2
 -- y+I1=[y] -----> a^3
 
--- Nota: Questo omomorfismo è iniettivo e ha come immagine
--- QQ[a^2,a^3], quindi non è surgettivo.
+-- Nota: Questo omomorfismo Ã¨ iniettivo e ha come immagine
+-- QQ[a^2,a^3], quindi non Ã¨ surgettivo.
 
 use ZZ/(4)[a,b]; -- just to make sure it's not using CurrentRing
 

--- a/src/CoCoA-5/tests/whatiscocoa.cocoa5
+++ b/src/CoCoA-5/tests/whatiscocoa.cocoa5
@@ -29,7 +29,7 @@ L;
 [ first(X,3) | X in L and X[4]=1 ];
 
 ----------------------------------------------------------------------
--- Chi è il mentitore?
+-- Chi Ã¨ il mentitore?
 use ZZ/(2)[a,b,c];
 I1 := ideal(a, b-1);
 I2 := ideal(a-1, b);


### PR DESCRIPTION
This adds an appropriate [.editorconfig](https://editorconfig.org/) file, which adjusts supported editors automagically.
The settings should somehow reflect the current state of "most" files.

Edit: Since `.editorconfig` now forces UTF-8 as the encoding, I converted all the files to UTF-8. Actually, only four files needed a conversion from ANSI to UTF-8 (done using `find . -type f -exec sh -c 'iconv -f $(file -bi "$1" |sed -e "s/.*[ ]charset=//") -t utf-8 > converted "$1" && mv converted "$1"' -- {} \;` from https://superuser.com/a/49147/1785373)