### PR TITLE
[WIP] Include Git revision in version info

### DIFF
--- a/configure
+++ b/configure
@@ -1227,6 +1227,20 @@ echo "# Version number of CoCoALib we shall build."           >> "$CONFIG_TMP"
 echo "COCOALIB_VERSION=$COCOALIB_VERSION"                     >> "$CONFIG_TMP"
 echo                                                          >> "$CONFIG_TMP"
 
+# Get current Git revision hash (if possible)
+COCOALIB_GIT_REV=$(git rev-parse --short HEAD)
+if [ $? -ne 0 ]
+then
+  COCOALIB_GIT_REV="unknown"
+elif [ -n "$(git status --porcelain)" ]
+then
+  # Check if the working directory is clean
+  COCOALIB_GIT_REV="$COCOALIB_GIT_REV-modified"
+fi
+echo "# Git revision hash of CoCoALib we shall build."        >> "$CONFIG_TMP"
+echo "COCOALIB_GIT_REV=$COCOALIB_GIT_REV"                     >> "$CONFIG_TMP"
+echo                                                          >> "$CONFIG_TMP"
+
 # Installation command and directory (just placeholders, 20140323)
 echo "Installation options are:"
 echo "  command   INSTALL_CMD          = $INSTALL_CMD"

--- a/include/CoCoA/BuildInfo.H
+++ b/include/CoCoA/BuildInfo.H
@@ -30,6 +30,7 @@ namespace CoCoA
   {
     // These are probably NOT noexcept because the 1st call creates a std::string object.
     const std::string& version();       ///< Which version of CoCoALib is this?
+    const std::string& GitRevision();   ///< Which Git revision of CoCoALib is this?
     const std::string& compiler();
     const std::string& CompilationFlags();
     const std::string& CompilationPlatform();

--- a/src/AlgebraicCore/BuildInfo.C
+++ b/src/AlgebraicCore/BuildInfo.C
@@ -33,12 +33,18 @@ namespace CoCoA
 
   namespace BuildInfo
   {
-    // Build info is actually passed in via three preprocessor variables:
-    // COCOA_VERSION, COCOA_CXX, COCOA_CXXFLAGS -- all three are quoted strings.
+    // Build info is actually passed in via these preprocessor variables:
+    // COCOA_VERSION, COCOA_GIT_REVISION, COCOA_CXX, COCOA_CXXFLAGS, COCOA_PLATFORM -- all are quoted strings.
 
     const std::string& version()
     {
       static const string info(COCOA_VERSION);
+      return info;
+    }
+
+    const std::string& GitRevision()
+    {
+      static const string info(COCOA_GIT_REVISION);
       return info;
     }
 
@@ -105,6 +111,7 @@ namespace CoCoA
       out << endl
           << "CoCoA::BuildInfo Summary of build information for CoCoALib:" << endl
           << "CoCoA::BuildInfo CoCoALib Version: " << version() << endl
+          << "CoCoA::BuildInfo CoCoALib Git Revision: " << GitRevision() << endl
           << "CoCoA::BuildInfo Compiler: " << compiler() << endl
           << "CoCoA::BuildInfo Compilation Flags: " << CompilationFlags() << endl
           << "CoCoA::BuildInfo Compilation Platform: " << CompilationPlatform() << endl

--- a/src/AlgebraicCore/Makefile
+++ b/src/AlgebraicCore/Makefile
@@ -114,7 +114,7 @@ check-source-files:
 BuildInfo.o: BuildInfo.C $(COCOA_ROOT)/include/CoCoA/BuildInfo.H
 	@echo "Compiling BuildInfo.o (with special preprocessor flags)"
 	PLATFORM=$$(uname -snr); \
-	$(COMPILE) -c  -DCOCOA_VERSION="\"$(COCOALIB_VERSION)\""  -DCOCOA_CXX="\"$(CXX)\""  -DCOCOA_CXXFLAGS="\"$(CXXFLAGS)\""  -DCOCOA_PLATFORM="\"$(PLATFORM)\""  -o BuildInfo.o BuildInfo.C
+	$(COMPILE) -c  -DCOCOA_VERSION="\"$(COCOALIB_VERSION)\""  -DCOCOA_GIT_REVISION="\"$(COCOALIB_GIT_REV)\""  -DCOCOA_CXX="\"$(CXX)\""  -DCOCOA_CXXFLAGS="\"$(CXXFLAGS)\""  -DCOCOA_PLATFORM="\"$(PLATFORM)\""  -o BuildInfo.o BuildInfo.C
 
 IdealOfPoints.o: IdealOfPoints.C $(COCOA_ROOT)/include/CoCoA/IdealOfPoints.H
 	@echo "Compiling IdealOfPoints --  keep your fingers crossed"

--- a/src/CoCoA-5/BuiltInFunctions.C
+++ b/src/CoCoA-5/BuiltInFunctions.C
@@ -673,6 +673,7 @@ DECLARE_STD_BUILTIN_FUNCTION(VersionInfo, 0) { // AMB
   intrusive_ptr<RECORD> rec(new RECORD);
   rec->setFieldNoCheck("CoCoALibVersion", Value::from(BuildInfo::version()));
   rec->setFieldNoCheck("CoCoAVersion", Value::from(CoCoAVersion()));
+  rec->setFieldNoCheck("CoCoAGitRevision", Value::from(BuildInfo::GitRevision()));
   rec->setFieldNoCheck("CompilationDate", Value::from(CompilationDate()));
   rec->setFieldNoCheck("CompilationFlags", Value::from(BuildInfo::CompilationFlags()));
   rec->setFieldNoCheck("CompilationPlatform", Value::from(BuildInfo::CompilationPlatform()));


### PR DESCRIPTION
Fixes #16

First proposal for including the Git revision hash in the version info somehow.
As it stands currently, I see the following issues:
- I tried to make this as safe as possible. For example, if the Git executable is not found, it should just print `unknown`. However, I am not an expert in bash scripts, so there may be minor or even major bugs.
- The entry `CoCoAGitRevision` is now at the very top in `indent(VersionInfo(), 2);`. This might not sound bad, but if you are used to seeing both CoCoALib and CoCoA versions as the first two entries, it certainly looks confusing now. Mabye, there is some better name, which lets the entry end up somewhere below these two? `CoCoAVersionRevision` or `CoCoAVersionGit` may do, but they are sub-optimal, to say the least.
- The inclusion of `-modified` as a way to identify versions that have been modified may not be the best approach. I didn't want to split it into a separate entry, though.
- Most critically: The Git revision hash currently is only updated when the `configure` script is run. I shall move it into the `make` process somewhere. Maybe into `src/AlgebraicCore/Makefile` under the `BuildInfo.o` task?

What do you think?
I think, having the Git revision would yield very useful information in future bug reports already at first glance.
But the way I do it in this PR is far from optimal, as the four listed issues show.