### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+ #   - name: Install necessary packages
+ #     uses: awalsh128/cache-apt-pkgs-action@v1
+ #     with:
+ #       packages: libgmp-dev libboost-dev libboost-filesystem-dev libboost-system-dev libreadline-dev gcc g++ make
+ #       execute_install_scripts: true
+ #       version: 1.0
+
+    - name: Install necessary packages
+      run: |
+        sudo apt update
+        sudo apt install libgmp-dev libboost-dev libboost-filesystem-dev libboost-system-dev libreadline-dev gcc g++ make
+
+    - name: Configure build
+      run: ./configure
+
+    - name: Compile and run tests
+      run: |
+        make -j8 check examples server
+        pushd src/CoCoA-5
+        make -j8 check wordlist
+        popd


### PR DESCRIPTION
This adds a simple CI workflow, which compiles CoCoALib, CoCoA 5 (without GUI only since I think that is sufficient for a CI workflow), CoCoA server, the examples and also runs the respective tests.
I have specifically excluded the `doc` targets because they depend on TeXLive, which would be a bit too much to install every time.
Already in its current state, the workflow needs ~5 minutes to finish.
The output of the workflow can be found here: https://github.com/cocoa-official/CoCoALib/actions/workflows/ci.yml (probably only after this PR is merged)

Fixes #17 