### PR TITLE
Proper error message when std::system is non-functional

### DIFF
--- a/src/CoCoA-5/BuiltInFunctions.C
+++ b/src/CoCoA-5/BuiltInFunctions.C
@@ -83,6 +83,9 @@ DECLARE_STD_BUILTIN_FUNCTION(SystemCommand, 1)
     throw RuntimeException("low-level \"std::system\" command unavailable", invocationExpression);
   if (!SystemCommandPermit::IsEnabled())
     throw RuntimeException("SystemCommand not enabled (see CoCoA interpreter launch options)", invocationExpression);
+  static int testCode = std::system("true");
+  if (testCode != 0)
+    throw RuntimeException("low-level \"std::system\" command is non-functional (see CoCoA manual for further info)", invocationExpression);
   intrusive_ptr<STRING> arg = runtimeEnv->evalArgAs<STRING>(ARG(0));
   std::cout << flush; // required according to man page at cppreference.com
   return Value::from(static_cast<long>(std::system(arg->theString.c_str())));

--- a/src/CoCoA-5/BuiltInFunctions.C
+++ b/src/CoCoA-5/BuiltInFunctions.C
@@ -83,9 +83,11 @@ DECLARE_STD_BUILTIN_FUNCTION(SystemCommand, 1)
     throw RuntimeException("low-level \"std::system\" command unavailable", invocationExpression);
   if (!SystemCommandPermit::IsEnabled())
     throw RuntimeException("SystemCommand not enabled (see CoCoA interpreter launch options)", invocationExpression);
-  static int testCode = std::system("true");
-  if (testCode != 0)
-    throw RuntimeException("low-level \"std::system\" command is non-functional (see CoCoA manual for further info)", invocationExpression);
+  {
+    static const bool StdSystemNotWorking = (std::system("true") != 0);
+    if (StdSystemNotWorking)
+      throw RuntimeException("low-level \"std::system\" command is non-functional (see CoCoA manual for further info)", invocationExpression);
+  }
   intrusive_ptr<STRING> arg = runtimeEnv->evalArgAs<STRING>(ARG(0));
   std::cout << flush; // required according to man page at cppreference.com
   return Value::from(static_cast<long>(std::system(arg->theString.c_str())));

--- a/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
+++ b/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
@@ -23204,7 +23204,7 @@ C++ run-time environment), so should not be relied upon to provide
 any specific information: <eg/> on some Linux systems the value returned
 is the exit code, on others it is 256 times the process exit code.
 <par/>
-NOTE: On Windows other than CygWin, the underlying <tt>std::system</tt>
+NOTE: On Windows outside of CygWin, the underlying <tt>std::system</tt>
 function simply returns 127 and does not execute the command. In these cases
 you will get an error message stating that the low-level <tt>std::system</tt>
 command is non-functional. This is a limitation of CygWin itself. This

--- a/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
+++ b/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
@@ -23203,6 +23203,14 @@ The return value of <tt>SystemCommand</tt> depends on the platform (<ie/> the
 C++ run-time environment), so should not be relied upon to provide
 any specific information: <eg/> on some Linux systems the value returned
 is the exit code, on others it is 256 times the process exit code.
+<par/>
+NOTE: On Windows other than CygWin, the underlying <tt>std::system</tt>
+function simply returns 127 and does not execute the command. In these cases
+you will get an error message stating that the low-level <tt>std::system</tt>
+command is non-functional. This is a limitation of CygWin itself. This
+problem can be solved by installing CygWin and running CoCoA-5 in the CygWin
+environment. This is also not a problem inside WSL using the Linux version of
+CoCoA-5 or on Windows using a UCRT-compiled version of CoCoA-5.
 <example>
 /**/ ExitCode := SystemCommand("echo abc");  --> value of ExitCode is unclear
 abc

--- a/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
+++ b/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
@@ -23205,12 +23205,12 @@ any specific information: <eg/> on some Linux systems the value returned
 is the exit code, on others it is 256 times the process exit code.
 <par/>
 NOTE: On Windows outside of CygWin, the underlying <tt>std::system</tt>
-function simply returns 127 and does not execute the command. In these cases
-you will get an error message stating that the low-level <tt>std::system</tt>
-command is non-functional. This is a limitation of CygWin itself. This
-problem can be solved by installing CygWin and running CoCoA-5 in the CygWin
-environment. This is also not a problem inside WSL using the Linux version of
-CoCoA-5 or on Windows using a UCRT-compiled version of CoCoA-5.
+function simply returns a non-zero value and does not execute the command. In
+these cases you will get an error message stating that the low-level
+<tt>std::system</tt> command is non-functional. This is a limitation of CygWin
+itself. This problem can be solved by installing CygWin and running CoCoA-5 in
+the CygWin environment. This is also not a problem inside WSL using the Linux
+version of CoCoA-5 or on Windows using a UCRT-compiled version of CoCoA-5.
 <example>
 /**/ ExitCode := SystemCommand("echo abc");  --> value of ExitCode is unclear
 abc


### PR DESCRIPTION
Fixes #34 
I am guessing that `true` can be executed on any system and leads to an exit code of `0`.
If not, are there any other options?
