### PR TITLE
Emacs 30 compatibility

### DIFF
--- a/src/AlgebraicCore/SparsePolyOps-LRSDegeneracy.C
+++ b/src/AlgebraicCore/SparsePolyOps-LRSDegeneracy.C
@@ -250,7 +250,7 @@ namespace CoCoA
      */
     std::vector<unsigned long> LRSDegeneracyOrders_modular(RingElem f, unsigned long MULT, VerificationLevel VerifLev, FirstOrAll StopCriterion)
     {
-      const char* const FnName = "LRSDegeneracyOrder_modular";
+      const char* const FnName = "LRSDegeneracyOrders_modular";
       VerboseLog VERBOSE(FnName);
 
       const ErrorContext context = CoCoA_ERROR_CONTEXT;
@@ -317,7 +317,7 @@ namespace CoCoA
           if (k % ListOfOrders[i] == 0)
             R /= CommonFac[i];
         R = gcd(R, fy);
-        if (!IsConstant(R)) 
+        if (!IsConstant(R))
         {
           ListOfOrders.push_back(k);
           CommonFac.push_back(R);

--- a/src/CoCoA-5/emacs/cocoa5.el
+++ b/src/CoCoA-5/emacs/cocoa5.el
@@ -1350,7 +1350,7 @@ Customization:
 ;;-------------------------------------------------------------->
 
 ;;;###autoload
-(defun cocoa5-mode ()
+(define-derived-mode cocoa5-mode ()
   "Major mode for editing a cocoa5 file that sends input to CoCoA.
 Editing mode with \\[cocoa5-send-line] sending the current line as input.
 
@@ -2156,7 +2156,7 @@ automatically when this function is called.
 
 ;; Font lock support
   (make-local-variable 'font-lock-defaults)
-  (setq font-lock-defaults '(cocoa5-font-lock-keywords nil nil))
+  (font-lock-add-keywords nil cocoa5-font-lock-keywords)
 ;; Imenu support
   (make-local-variable 'imenu-generic-expression)
   (setq imenu-generic-expression cocoa5-imenu-generic-expression)


### PR DESCRIPTION
This PR fixes the `FnName` for `LRSDegeneracyOrders_modular` and the elisp file for Emacs 30.
I recently updated to emacs 30 and CoCoA-5's syntax highlighting did not work anymore.
After some searching, I found this thread: https://lists.nongnu.org/archive/html/help-gnu-emacs/2025-03/msg00291.html
which lead me to Emacs 30's NEWS entry as well as these two commits:
https://github.com/Thaodan/rpm-spec-mode/commit/5d8bc10065808eba97254da74342e8c86609c57a
https://github.com/Thaodan/rpm-spec-mode/commit/f099e01fdb74cf4c18d7846572cb4b4d15c95fdc

Applying a similar fix to CoCoA-5's elisp file makes everything work fine again (and according to what I read, this should be compatible with Emacs 22+, but I have only tested 29.4 and 30.1 so far...)