### PR TITLE
Added checks in Makefiles for python/java -- required to build doc

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -49,6 +49,16 @@ CoCoALib.pdf:  $(COCOA_ROOT)/configuration/version  $(DOC_SRCS)  $(AUX_DIR)/DocT
 	   sleep 2; \
 	   exit; \
 	 fi; \
+	 txt2tags --version >/dev/null 2>&1 ; \
+	 if [ $$? -ne 0 ]; \
+	 then \
+	   echo ">>>>>>>>>>>>>>>>>>>>>> WARNING <<<<<<<<<<<<<<<<<<<<<<"; \
+	   echo ">>>  Python not installed!   Please install it!   <<<"; \
+	   echo ">>>  Required for txt2tags (used to build doc)    <<<"; \
+	   echo ">>>>>>>>>>>>>>>>>>>> END WARNING <<<<<<<<<<<<<<<<<<<<"; \
+	   sleep 2; \
+	   exit; \
+	 fi; \
 	 $(MAKE)  $(TEX_DIR)/CoCoALib.tex  $(TEX_DIR)/cocoalib-doc.sty; \
 	 if [ \! -f "$(TEX_DIR)/CoCoALib.tex" ]; then echo; echo "ERROR!!!  FAILED TO MAKE $(TEX_DIR)/CoCoALib.tex"; echo; exit 1; fi; \
 	 echo "Doing LaTeX-->PDF"; \

--- a/src/CoCoA-5/CoCoAManual/Makefile
+++ b/src/CoCoA-5/CoCoAManual/Makefile
@@ -14,11 +14,22 @@ COCOA5_DOC_TEX_DIR=tex
 
 # Default target
 .PHONY: pdf-and-html-doc
-pdf-and-html-doc: $(COCOA5_DOC_HTML_DIR)/TimeStamp  $(COCOA5_DOC_TEX_DIR)/TimeStamp
+pdf-and-html-doc:  $(COCOA5_DOC_HTML_DIR)/TimeStamp  $(COCOA5_DOC_TEX_DIR)/TimeStamp
 
 # Target for HTML files: uses a TimeStamp to tell whether needs to be rebuilt
 $(COCOA5_DOC_HTML_DIR)/TimeStamp:  CoCoAHelp.xml  aux-files/GUI_help.xsl
-	/bin/mkdir -p $(COCOA5_DOC_HTML_DIR)
+	@command -v java >/dev/null 2>&1 || java --version >/dev/null 2>&1 ; \
+	 if [ $$? -ne 0 ]; \
+	 then \
+	   echo ">>>>>>>>>>>>>>>>>>>>>> WARNING <<<<<<<<<<<<<<<<<<<<<<"; \
+	   echo ">>>  Cannot build CoCoA-5 HTML documentation!     <<<"; \
+	   echo ">>>  Please install java (sorry!)                 <<<"; \
+	   echo ">>>>>>>>>>>>>>>>>>>> END WARNING <<<<<<<<<<<<<<<<<<<<"; \
+	   echo; \
+	   sleep 2; \
+	   exit; \
+	 fi; \
+	/bin/mkdir -p $(COCOA5_DOC_HTML_DIR); \
 	cd $(COCOA5_DOC_HTML_DIR); \
 	touch WillBecomeTimeStamp; \
 	java -jar  ../aux-files/saxon.jar  ../$(COCOA5_DOC_XML)  ../aux-files/GUI_help.xsl  CoCoAVersion="$(COCOA5_VER_MAJ).$(COCOA5_VER_MIN).$(COCOA5_VER_MINMIN)" ; \
@@ -27,7 +38,18 @@ $(COCOA5_DOC_HTML_DIR)/TimeStamp:  CoCoAHelp.xml  aux-files/GUI_help.xsl
 
 
 $(COCOA5_DOC_TEX_DIR)/TimeStamp:  CoCoAHelp.xml  aux-files/TeX.xsl  aux-files/TeX-extra-files/mybook.cls
-	/bin/mkdir -p $(COCOA5_DOC_TEX_DIR)
+	@command -v java >/dev/null 2>&1 || java --version >/dev/null 2>&1 ; \
+	 if [ $$? -ne 0 ]; \
+	 then \
+	   echo ">>>>>>>>>>>>>>>>>>>>>> WARNING <<<<<<<<<<<<<<<<<<<<<<"; \
+	   echo ">>>  Cannot build CoCoA-5 PDF documentation!      <<<"; \
+	   echo ">>>  Please install java (sorry!)                 <<<"; \
+	   echo ">>>>>>>>>>>>>>>>>>>> END WARNING <<<<<<<<<<<<<<<<<<<<"; \
+	   echo; \
+	   sleep 2; \
+	   exit; \
+	 fi; \
+	/bin/mkdir -p $(COCOA5_DOC_TEX_DIR); \
 	cd $(COCOA5_DOC_TEX_DIR); \
 	touch WillBecomeTimeStamp; \
 	java -jar ../aux-files/saxon.jar  ../$(COCOA5_DOC_XML)  ../aux-files/TeX.xsl  CoCoAVersion="$(COCOA5_VER_MAJ).$(COCOA5_VER_MIN).$(COCOA5_VER_MINMIN)"  > CoCoAManual.tex

--- a/src/CoCoA-5/Makefile
+++ b/src/CoCoA-5/Makefile
@@ -60,7 +60,7 @@ COMPILE5=$(COMPILE) $(CXXFLAGS_CUSTOM)  $(COCOA5_CXX_DEFINES)
 	$(COMPILE5) -c -o $@ $<
 
 
-CoCoAInterpreter: VersionInfo.o  CompilationDate.o
+CoCoAInterpreter:  VersionInfo.o  CompilationDate.o
 	@echo "CoCoAInterpreter: linking everything together"
 	$(COMPILE5) $(OBJS) CompilationDate.o -o CoCoAInterpreter  $(LDLIBS)  $(COCOA5_LDLIBS)  -lpthread
 	@#Next lines remove the *.dSYM directory which the Apple compiler creates
@@ -73,22 +73,22 @@ CoCoAInterpreter: VersionInfo.o  CompilationDate.o
 	fi
 
 
-VersionInfo.o: VersionInfo.C  check-version-defines  version.mk
+VersionInfo.o:  VersionInfo.C  check-version-defines  version.mk
 	@echo "Compiling VersionInfo.o (with special preprocessor flags)"
 	$(COMPILE) -c $(COCOA5_VERSION_DEFINES) -o VersionInfo.o VersionInfo.C
 
 
 .PHONY: cocoa5
-cocoa5: check-prerequisites-verbose  check-cocoalib
+cocoa5:  check-prerequisites-verbose  check-cocoalib
 	@$(MAKE) CoCoAInterpreter
 
-.PHONY: check-cocoalib
+.PHONY:  check-cocoalib
 check-cocoalib:
 	@(cd ../..; $(MAKE) -s lib)
 
 
 # This target checks that the 3 fields for the version are purely alphanumeric
-check-version-defines: check-version-defines.C  version.mk
+check-version-defines:  check-version-defines.C  version.mk
 	@$(COMPILE)  $(COCOA5_VERSION_DEFINES)  -o check-version-defines  check-version-defines.C
 	@./check-version-defines; if [ $$? -ne 0 ]; \
 	then \
@@ -116,7 +116,7 @@ check-prerequisites-verbose:
 
 
 .PHONY: check
-check: cocoa5
+check:  cocoa5
 	@cd tests; $(MAKE) -s check
 
 
@@ -124,7 +124,7 @@ check: cocoa5
 # This part is relevant only if the QT-gui is present
 
 .PHONY: Qt-gui
-Qt-gui: check-prerequisites-verbose  $(OBJS)  $(COCOA_LIB)  QCodeEdit/Makefile  C5Makefile
+Qt-gui:  check-prerequisites-verbose  $(OBJS)  $(COCOA_LIB)  QCodeEdit/Makefile  C5Makefile
 	@echo "-----------------------------------"
 	@echo ">>>>  Making the CoCoA Qt GUI  <<<<"
 	@echo "-----------------------------------"
@@ -149,7 +149,7 @@ C5Makefile:  $(COCOA_LIB)  C5.pro.in  make-c5makefile.sh
 
 
 .PHONY: install
-install: cocoa5 doc wordlist
+install:  cocoa5  doc  wordlist
 	@echo "===================================================================="
 	@echo ">>> WARNING: CoCoA-5 installation procedure is still PRELIMINARY <<<"
 	@echo "===================================================================="
@@ -165,13 +165,13 @@ install: cocoa5 doc wordlist
 	/bin/mkdir -m 755 "$$SUBDIR"; \
 	/bin/cp -r packages emacs "$$SUBDIR"; \
 	/bin/chmod 755 "$$SUBDIR/packages" "$$SUBDIR/emacs"; \
-	$(INSTALL_CMD) -m 755 cocoa5 CoCoAInterpreter "$$SUBDIR"; \
+	$(INSTALL_CMD) -m 755  cocoa5  CoCoAInterpreter "$$SUBDIR"; \
 	/bin/mkdir -m 755 "$$SUBDIR/CoCoAManual"; \
 	/bin/cp -r CoCoAManual/html  "$$SUBDIR/CoCoAManual"; \
-	$(INSTALL_CMD) -m 644 CoCoAManual/tex/CoCoAManual.pdf  "$$SUBDIR/CoCoAManual"; \
-	$(INSTALL_CMD) -m 644 CoCoAManual/CoCoAHelp.xml  "$$SUBDIR/CoCoAManual"; \
-	$(INSTALL_CMD) -m 644 CoCoAManual/wordlist.txt  "$$SUBDIR/CoCoAManual"; \
-	$(INSTALL_CMD) -m 644 ../../doc/CoCoATranslationTable.html  "$$SUBDIR/CoCoAManual"; \
+	$(INSTALL_CMD) -m 644  CoCoAManual/tex/CoCoAManual.pdf  "$$SUBDIR/CoCoAManual"; \
+	$(INSTALL_CMD) -m 644  CoCoAManual/CoCoAHelp.xml  "$$SUBDIR/CoCoAManual"; \
+	$(INSTALL_CMD) -m 644  CoCoAManual/wordlist.txt  "$$SUBDIR/CoCoAManual"; \
+	$(INSTALL_CMD) -m 644  ../../doc/CoCoATranslationTable.html  "$$SUBDIR/CoCoAManual"; \
 	/bin/rm -f "$(COCOA5_INSTALL_DIR)/cocoa5"; \
 	/bin/ln -s "$$SUBDIR/cocoa5" "$(COCOA5_INSTALL_DIR)"
 	@echo "CoCoA-5 installed in $(COCOA5_INSTALL_DIR)"
@@ -180,7 +180,7 @@ install: cocoa5 doc wordlist
 AllExamples.o: $(COCOA_ROOT)/configuration/autoconf.mk
 
 .PHONY: ManExamples
-ManExamples: cocoa5 OnlineHelp.o  PrintManExamples.o
+ManExamples:  cocoa5  OnlineHelp.o  PrintManExamples.o
 	$(COMPILE5) OnlineHelp.o  PrintManExamples.o  -o PrintManExamples $(LDLIBS)
 	/bin/rm -rf PrintManExamples.dSYM # Apple's compiler creates this dir
 	@echo "creating ManExamples-in.cocoa5 ...";
@@ -194,10 +194,10 @@ ManExamples: cocoa5 OnlineHelp.o  PrintManExamples.o
 	@echo "===================================================="
 
 
-wordlist.o: $(COCOA_ROOT)/configuration/autoconf.mk
+wordlist.o:  $(COCOA_ROOT)/configuration/autoconf.mk
 
 .PHONY: wordlist
-wordlist: $(COCOA5_WORDLIST)
+wordlist:  $(COCOA5_WORDLIST)
 
 $(COCOA5_WORDLIST):  OnlineHelp.C  wordlist.C  $(COCOA5_DOC_XML)
 	$(MAKE)  -s  OnlineHelp.o  wordlist.o
@@ -207,7 +207,7 @@ $(COCOA5_WORDLIST):  OnlineHelp.C  wordlist.C  $(COCOA5_DOC_XML)
 	@/bin/rm PrintWordlist
 
 .PHONY: doc
-doc:
+doc:  cocoa5
 	@(cd $(COCOA5_DOC_DIR); $(MAKE))
 
 


### PR DESCRIPTION
I've added checks that `txt2tags` is installed and runs (enough to print its version).
I've added check that `java` is installed and runs (enough to print its version).
Better spacing in `src/CoCoA-5/Makefile`