### PR TITLE
Avoid multiplying by zero inside matrix product

### DIFF
--- a/src/AlgebraicCore/MatrixOps-arith.C
+++ b/src/AlgebraicCore/MatrixOps-arith.C
@@ -63,7 +63,8 @@ namespace CoCoA
         CheckForInterrupt("Matrix multiplication");
         RingElem tmp(Rleft);
         for (long k=0; k < N; ++k)
-          tmp += Mleft(i,k)*Mright(k,j);
+          if (!IsZero(Mleft(i,k)) && !IsZero(Mright(k,j))) // helpful if matrix is somewhat "sparse"
+            tmp += Mleft(i,k)*Mright(k,j);
         SetEntry(ans, i, j, tmp);
       }
     return ans;


### PR DESCRIPTION
If the matrices contain many zero entries then this small change can make matrix product faster (_e.g._ by a factor of 2)