### PR TITLE
Added call to reserve for vectors

### DIFF
--- a/include/CoCoA/TmpGReductor.H
+++ b/include/CoCoA/TmpGReductor.H
@@ -199,12 +199,12 @@ public:
                                 const GRingInfo& theGRI);
  			
   // The special poly embedding used in colon computations
-    GPolyList ColonEmbedVectorLists(const VectorList& VL1,
-                                    const VectorList& VL2,
+    GPolyList ColonEmbedVectorLists(const VectorList& VL,
+                                    const ModuleElem& v,
                                     const GRingInfo& theGRI);
 				
-    GPolyList ColonEmbedPolyLists(const PolyList& PL1,
-                                  const PolyList& PL2,
+    GPolyList ColonEmbedPolyLists(const PolyList& F,
+                                  const RingElem& f,
                                   const GRingInfo& theGRI);
 
     void SyzEmbedGPolyList(GPolyList& theGPL);

--- a/src/AlgebraicCore/TmpGOperations.C
+++ b/src/AlgebraicCore/TmpGOperations.C
@@ -324,8 +324,9 @@ namespace CoCoA
 
     std::vector<long> PPIndices(ConstRefPPMonoidElem t)
     {
-      std::vector<long> indices;  indices.reserve(len(tmp));
+      std::vector<long> indices;
       std::vector<long> tmp = exponents(t);
+      indices.reserve(len(tmp));
       for (long i=0; i < len(tmp); ++i)
         if (tmp[i]!=0)  indices.push_back(i);
       return indices;

--- a/src/AlgebraicCore/TmpGOperations.C
+++ b/src/AlgebraicCore/TmpGOperations.C
@@ -47,14 +47,14 @@ namespace CoCoA
 
   namespace // anonymous
   { // namespace // anonymous ----------------------------------------------
-    bool IsHomogGrD0(const PolyList& L)
+    bool IsHomogGrD0(const std::vector<RingElem>& L)
     {
       if (L.empty()) return true;
       if (GradingDim(owner(L[0]))==0) return true;
       return IsHomog(L);
     }
 
-    bool IsHomogGrD0(const VectorList& L)
+    bool IsHomogGrD0(const std::vector<ModuleElem>& L)
     {
       if (L.empty()) return true;
       if (GradingDim(RingOf(owner(L[0])))==0) return true;
@@ -74,7 +74,7 @@ namespace CoCoA
     }
 
 
-    PolyList KxToRx(const PolyList& F, SparsePolyRing Rx)
+    std::vector<RingElem> KxToRx(const std::vector<RingElem>& F, SparsePolyRing Rx)
     {
       if (F.empty()) return F;
       CoCoA_ASSERT(HasUniqueOwner(F));
@@ -82,9 +82,10 @@ namespace CoCoA
       CoCoA_ASSERT(IsFractionFieldOfGCDDomain(CoeffRing(Kx)));
       CoCoA_ASSERT(BaseRing(CoeffRing(Kx)) == CoeffRing(Rx));
       CoCoA_ASSERT(ordering(PPM(Kx)) == ordering(PPM(Rx)));
-      PolyList F_Rx;
+      std::vector<RingElem> F_Rx;
       RingElem f_Rx(Rx);
       std::vector<long> expv(NumIndets(Rx));
+      F_Rx.reserve(len(F));
       for (const RingElem& f: F)
       {
         const RingElem d(CommonDenom(f));
@@ -97,7 +98,7 @@ namespace CoCoA
     }
 
 
-    PolyList RxToKx(const PolyList& F, SparsePolyRing Kx)
+    std::vector<RingElem> RxToKx(const std::vector<RingElem>& F, SparsePolyRing Kx)
     {
       CoCoA_ASSERT(IsFractionField(CoeffRing(Kx)));
       if (F.empty()) return F;
@@ -149,8 +150,8 @@ namespace CoCoA
   } // ComputeGBasis2
 
 
-  void ComputeGBasis2(PolyList& GB_out, PolyList& MinGens_out,
-                      const PolyList& G_in, const CpuTimeLimit& CheckForTimeout)
+  void ComputeGBasis2(std::vector<RingElem>& GB_out, std::vector<RingElem>& MinGens_out,
+                      const std::vector<RingElem>& G_in, const CpuTimeLimit& CheckForTimeout)
   {
     if (G_in.empty())
     {
@@ -161,8 +162,8 @@ namespace CoCoA
     SparsePolyRing P(owner(G_in[0]));
     if (!IsField(CoeffRing(P)))  CoCoA_THROW_ERROR1(ERR::ReqCoeffsInField);
     bool IsSatAlg=false;
-    PolyList GB_tmp;
-    PolyList MinGens_tmp;
+    std::vector<RingElem> GB_tmp;
+    std::vector<RingElem> MinGens_tmp;
     if (IsFractionFieldOfGCDDomain(CoeffRing(P)))
     {
       const ring R = BaseRing(CoeffRing(P));
@@ -326,6 +327,7 @@ namespace CoCoA
     {
       std::vector<long> indices;
       std::vector<long> tmp = exponents(t);
+      indices.reserve(len(tmp));
       for (long i=0; i < len(tmp); ++i)
         if (tmp[i]!=0)  indices.push_back(i);
       return indices;
@@ -363,11 +365,13 @@ namespace CoCoA
     SparsePolyRing P_work=MakeElimRing(P, PPIndices(inds), HomogInput);
     RingHom PToNew = PolyAlgebraHom(P, P_work, indets(P_work));
     RingHom NewToP = PolyAlgebraHom(P_work, P, indets(P));
-    PolyList NewGens;
+    std::vector<RingElem> NewGens;
+    NewGens.reserve(len(G));
     for (const RingElem& g: G) NewGens.push_back(PToNew(g));
     PPMonoidElem ElimIndsProd(LPP(PToNew(monomial(P,inds))));
-    PolyList GB = ComputeGBasis(NewGens, CheckForTimeout);
-    PolyList ElimGens;
+    std::vector<RingElem> GB = ComputeGBasis(NewGens, CheckForTimeout);
+    std::vector<RingElem> ElimGens;
+    NewGens.reserve(len(GB));
     for (const RingElem& g: GB)
     {
       if ( IsConstant(g) ) // redmine #1647
@@ -499,7 +503,7 @@ namespace CoCoA
       const SparsePolyRing P_work(MakeNewPRingFromModule(FM, WDegPosTO));
       GRingInfo GRI(P_work, RingOf(FM), FM, FM, IsHomogGrD0(G1)&&IsHomogGrD0(v),
                     IsSatAlg, NewDivMaskEvenPowers(), CheckForTimeout);
-      GReductor GBR(GRI, ColonEmbedVectorLists(G1, VectorList(1,v), GRI));
+      GReductor GBR(GRI, ColonEmbedVectorLists(G1, v, GRI));
       GBR.myDoGBasis();// homog input standard alg interred
       return DeEmbedPolyListToPL(GBR.myExportGBasis(), GRI, NumCompts(FM));
     }
@@ -516,8 +520,7 @@ namespace CoCoA
       const SparsePolyRing P_work(MakeNewPRingForP2_PosTO(P,IsHomogGrD0(G)&&IsHomogGrD0(f)));
       GRingInfo GRI(P_work, P, IsHomogGrD0(G) && IsHomogGrD0(f),
                     IsSatAlg,NewDivMaskEvenPowers(), CheckForTimeout);
-      GPolyList EmbeddedPolys=ColonEmbedPolyLists(G, std::vector<RingElem>{f}, GRI);
-      GReductor GBR(GRI, EmbeddedPolys);
+      GReductor GBR(GRI, ColonEmbedPolyLists(G, f, GRI));
       GBR.myDoGBasis();// homog input standard alg interred
       return DeEmbedPolyListToPL(GBR.myExportGBasis(), GRI, 1);
     }
@@ -593,6 +596,8 @@ namespace CoCoA
     {
       if (len(G1) != len(G2))  return false;
       std::vector<PolyList::const_iterator> v1,v2;
+      v1.reserve(len(G1));
+      v2.reserve(len(G2));
       for (PolyList::const_iterator it=G1.begin(); it!=G1.end(); ++it)
         v1.push_back(it);
       for (PolyList::const_iterator it=G2.begin(); it!=G2.end(); ++it)
@@ -642,7 +647,9 @@ namespace CoCoA
       const ring& K = CoeffRing(P); // CoCoA_ASSERT(IsField(k));
       const long GrDim = GradingDim(P);
       const long NumX = NumIndets(P);
-      std::vector<symbol> names;  for (long i=0; i<NumX; ++i) { names.push_back(IndetSymbol(P,i)); }
+      std::vector<symbol> names;
+      names.reserve(NumX);
+      for (long i=0; i<NumX; ++i)  names.push_back(IndetSymbol(P,i));
       VERBOSE(90) << "GrDim = " << GrDim << "   W = " << GradingMat(P) << std::endl;
       matrix W0 = NewDenseMat(ConcatVer(GradingMat(P), ZeroMat(RingZZ(), 1, NumIndets(P))));
       PolyList tmpGens = G;
@@ -755,13 +762,16 @@ namespace CoCoA
   }
 
 
-  PolyList ComputeHomogenization(const PolyList& G, const PolyList& HomogIndets,
-                                 const CpuTimeLimit& CheckForTimeout)
+  std::vector<RingElem> ComputeHomogenization(const std::vector<RingElem>& G,
+                                              const std::vector<RingElem>& HomogIndets,
+                                              const CpuTimeLimit& CheckForTimeout)
   {
     if (G.empty()) return G;
     RingElem IndetProd(product(HomogIndets));
-    PolyList tmpHGens;
-    for (const RingElem& g: G) tmpHGens.push_back(homog(g, HomogIndets));
+    std::vector<RingElem> tmpHGens;
+    tmpHGens.reserve(len(G));
+    for (const RingElem& g: G)
+      tmpHGens.push_back(homog(g, HomogIndets));
     return ComputeSaturationByPrincipal(tmpHGens,IndetProd,CheckForTimeout);
   }
 

--- a/src/AlgebraicCore/TmpGOperations.C
+++ b/src/AlgebraicCore/TmpGOperations.C
@@ -595,9 +595,9 @@ namespace CoCoA
       std::vector<PolyList::const_iterator> v1,v2;
       v1.reserve(len(G1));
       v2.reserve(len(G2));
-      for (const auto& it=G1.begin(); it!=G1.end(); ++it)
+      for (auto it=G1.begin(); it!=G1.end(); ++it)
         v1.push_back(it);
-      for (const auto& it=G2.begin(); it!=G2.end(); ++it)
+      for (auto it=G2.begin(); it!=G2.end(); ++it)
         v2.push_back(it);
       stable_sort(v1.begin(), v1.end(), ByLPP);
       stable_sort(v2.begin(), v2.end(), ByLPP);

--- a/src/AlgebraicCore/TmpGOperations.C
+++ b/src/AlgebraicCore/TmpGOperations.C
@@ -82,10 +82,9 @@ namespace CoCoA
       CoCoA_ASSERT(IsFractionFieldOfGCDDomain(CoeffRing(Kx)));
       CoCoA_ASSERT(BaseRing(CoeffRing(Kx)) == CoeffRing(Rx));
       CoCoA_ASSERT(ordering(PPM(Kx)) == ordering(PPM(Rx)));
-      std::vector<RingElem> F_Rx;
+      std::vector<RingElem> F_Rx;  F_Rx.reserve(len(F));
       RingElem f_Rx(Rx);
       std::vector<long> expv(NumIndets(Rx));
-      F_Rx.reserve(len(F));
       for (const RingElem& f: F)
       {
         const RingElem d(CommonDenom(f));
@@ -325,9 +324,8 @@ namespace CoCoA
 
     std::vector<long> PPIndices(ConstRefPPMonoidElem t)
     {
-      std::vector<long> indices;
+      std::vector<long> indices;  indices.reserve(len(tmp));
       std::vector<long> tmp = exponents(t);
-      indices.reserve(len(tmp));
       for (long i=0; i < len(tmp); ++i)
         if (tmp[i]!=0)  indices.push_back(i);
       return indices;
@@ -365,13 +363,11 @@ namespace CoCoA
     SparsePolyRing P_work=MakeElimRing(P, PPIndices(inds), HomogInput);
     RingHom PToNew = PolyAlgebraHom(P, P_work, indets(P_work));
     RingHom NewToP = PolyAlgebraHom(P_work, P, indets(P));
-    std::vector<RingElem> NewGens;
-    NewGens.reserve(len(G));
+    std::vector<RingElem> NewGens;  NewGens.reserve(len(G));
     for (const RingElem& g: G) NewGens.push_back(PToNew(g));
     PPMonoidElem ElimIndsProd(LPP(PToNew(monomial(P,inds))));
     std::vector<RingElem> GB = ComputeGBasis(NewGens, CheckForTimeout);
-    std::vector<RingElem> ElimGens;
-    NewGens.reserve(len(GB));
+    std::vector<RingElem> ElimGens;  ElimGens.reserve(len(GB));
     for (const RingElem& g: GB)
     {
       if ( IsConstant(g) ) // redmine #1647
@@ -598,9 +594,9 @@ namespace CoCoA
       std::vector<PolyList::const_iterator> v1,v2;
       v1.reserve(len(G1));
       v2.reserve(len(G2));
-      for (PolyList::const_iterator it=G1.begin(); it!=G1.end(); ++it)
+      for (const auto& it=G1.begin(); it!=G1.end(); ++it)
         v1.push_back(it);
-      for (PolyList::const_iterator it=G2.begin(); it!=G2.end(); ++it)
+      for (const auto& it=G2.begin(); it!=G2.end(); ++it)
         v2.push_back(it);
       stable_sort(v1.begin(), v1.end(), ByLPP);
       stable_sort(v2.begin(), v2.end(), ByLPP);
@@ -647,8 +643,7 @@ namespace CoCoA
       const ring& K = CoeffRing(P); // CoCoA_ASSERT(IsField(k));
       const long GrDim = GradingDim(P);
       const long NumX = NumIndets(P);
-      std::vector<symbol> names;
-      names.reserve(NumX);
+      std::vector<symbol> names;  names.reserve(NumX);
       for (long i=0; i<NumX; ++i)  names.push_back(IndetSymbol(P,i));
       VERBOSE(90) << "GrDim = " << GrDim << "   W = " << GradingMat(P) << std::endl;
       matrix W0 = NewDenseMat(ConcatVer(GradingMat(P), ZeroMat(RingZZ(), 1, NumIndets(P))));
@@ -768,8 +763,7 @@ namespace CoCoA
   {
     if (G.empty()) return G;
     RingElem IndetProd(product(HomogIndets));
-    std::vector<RingElem> tmpHGens;
-    tmpHGens.reserve(len(G));
+    std::vector<RingElem> tmpHGens;  tmpHGens.reserve(len(G));
     for (const RingElem& g: G)
       tmpHGens.push_back(homog(g, HomogIndets));
     return ComputeSaturationByPrincipal(tmpHGens,IndetProd,CheckForTimeout);

--- a/src/AlgebraicCore/TmpGReductor.C
+++ b/src/AlgebraicCore/TmpGReductor.C
@@ -100,7 +100,7 @@ namespace CoCoA
 
 
   GReductor::GReductor(const GRingInfo& theGRI,
-                       const PolyList& TheInputPolys,
+                       const std::vector<RingElem>& F,
                        const BuchbergerOpTypeFlag theBuchbergerOpType,
                        const GBCriteria criteria):
       myGRingInfoValue(theGRI),
@@ -108,16 +108,13 @@ namespace CoCoA
       mySPoly(theGRI),
       myOldDeg(GradingDim(theGRI.myNewSPR())),
       myIncomingWDeg(GradingDim(theGRI.myNewSPR())),
-      myStat(len(TheInputPolys)),
+      myStat(len(F)),
       myCriteria(criteria)
   {
     myCtorAux(theBuchbergerOpType);
-
-    for (const RingElem& g: TheInputPolys)
-    {
+    for (const RingElem& g: F)
       if (!IsZero(g))
-        myPolys.push_back(GPoly(g,myGRingInfoValue));
-    }
+        myPolys.push_back(GPoly(g,myGRingInfoValue)); // list
     myPolys.sort(BoolCmpLPPGPoly);
     myTruncDegValue = ourNoTruncValue;
   } //  GReductor ctor
@@ -208,6 +205,7 @@ namespace CoCoA
   std::vector<RingElem> GReductor::myExportGBasis()
   {
     std::vector<RingElem> GB;
+    GB.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsActive(*ptr))  GB.push_back(poly(*ptr));
     return GB;
@@ -217,6 +215,7 @@ namespace CoCoA
   std::vector<RingElem> GReductor::myExportMinGens()
   {
     std::vector<RingElem> G;
+    G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsMinimalGen(*ptr))  G.push_back(poly(*ptr));
     return G;
@@ -263,21 +262,23 @@ namespace CoCoA
 
   std::vector<ModuleElem> GReductor::myExportGBasis_module()
   {
-    std::vector<ModuleElem>  outG;
+    std::vector<ModuleElem>  G;
+    G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsActive(*ptr))
-        outG.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
-    return outG;
+        G.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
+    return G;
   }
 
 
   std::vector<ModuleElem> GReductor::myExportMinGens_module()
   {
-    std::vector<ModuleElem>  outG;
+    std::vector<ModuleElem>  G;
+    G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsMinimalGen(*ptr))
-        outG.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
-    return outG;
+        G.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
+    return G;
   }
 
 
@@ -936,7 +937,7 @@ namespace CoCoA
     }
 
 
-    GPolyList EmbedPolyList(const PolyList& F,
+    GPolyList EmbedPolyList(const std::vector<RingElem>& F,
                             const GRingInfo& GRI,
                             const long CompIndex)
     {
@@ -947,7 +948,7 @@ namespace CoCoA
     }
 
 
-    GPolyList EmbedPolyListNo0(const PolyList& F,
+    GPolyList EmbedPolyListNo0(const std::vector<RingElem>& F,
                                const GRingInfo& GRI,
                                const long CompIndex)
     {
@@ -989,11 +990,11 @@ Is is here only for completeness/debug purposes.
   } // namespace // anonymous
 
 
-  GPolyList EmbedVectorList(const VectorList& VL, const GRingInfo& GRI)
+  GPolyList EmbedVectorList(const std::vector<ModuleElem>& VL, const GRingInfo& GRI)
   { return EmbedVectorList(VL, GRI, 0); }
 
 
-  GPolyList EmbedVectorList(const VectorList& VL,
+  GPolyList EmbedVectorList(const std::vector<ModuleElem>& VL,
                             const GRingInfo& theGRI,
                             const long StartingFromCompIndex)
   {
@@ -1006,7 +1007,7 @@ Is is here only for completeness/debug purposes.
   } // EmbedVectorList		
 
 
-  GPolyList SyzEmbedVectorList(const VectorList& InputVectorList,
+  GPolyList SyzEmbedVectorList(const std::vector<ModuleElem>& InputVectorList,
                                const GRingInfo& GRI)
   {
     GPolyList outPL;
@@ -1031,13 +1032,13 @@ Is is here only for completeness/debug purposes.
   } // SyzEmbedVectorList
 
 
-  GPolyList SyzEmbedPolyList(const PolyList& InputPolyList,
+  GPolyList SyzEmbedPolyList(const std::vector<RingElem>& F,
                              const GRingInfo& theGRI)
   {
     GPolyList outPL;
-    if (InputPolyList.empty())  return outPL;
+    if (F.empty())  return outPL;
     const SparsePolyRing NewP=theGRI.myNewSPR();
-    outPL=EmbedPolyList(InputPolyList, theGRI, 0);
+    outPL = EmbedPolyList(F, theGRI, 0);
     RingElem SyzPP(NewP); // Gives the right degree to p+E^i
     degree d(GradingDim(NewP));
     long k=1;
@@ -1062,23 +1063,23 @@ Is is here only for completeness/debug purposes.
   } // SyzEmbedPolyList
 
 
-  GPolyList IntEmbedPolyLists(const PolyList& PL1,
-                              const PolyList& PL2,
+  GPolyList IntEmbedPolyLists(const std::vector<RingElem>& F1,
+                              const std::vector<RingElem>& F2,
                               const GRingInfo& GRI)
   {
-    GPolyList Part1 = EmbedPolyListNo0(PL1, GRI, 0);
-    GPolyList Part2 = EmbedPolyListNo0(PL2, GRI, 0);
-    GPolyList Part3 = EmbedPolyListNo0(PL2, GRI, 1);
+    GPolyList Part1 = EmbedPolyListNo0(F1, GRI, 0);
+    GPolyList Part2 = EmbedPolyListNo0(F2, GRI, 0);
+    GPolyList Part3 = EmbedPolyListNo0(F2, GRI, 1);
     GPolyList::iterator it3=Part3.begin();
     for (GPolyList::iterator it2=Part2.begin(); it2!=Part2.end(); ++it2,++it3)
       (*it2).myAppendClear(*it3);
     Part2.splice(Part2.begin(), Part1);
     return Part2;
-  } // IntEmbedPolyLists
+  }
 
 
-  GPolyList IntEmbedVectorLists(const VectorList& theVL1,
-                                const VectorList& theVL2,
+  GPolyList IntEmbedVectorLists(const std::vector<ModuleElem>& theVL1,
+                                const std::vector<ModuleElem>& theVL2,
                                 const GRingInfo& theGRI)
   {
     const long NC = NumCompts(owner(theVL1[0]));
@@ -1091,73 +1092,71 @@ Is is here only for completeness/debug purposes.
       (*it).myAppendClear(*it1);
     SecondPart.splice(SecondPart.begin(),FirstPart);
     return SecondPart;
-  } // IntEmbedVectorLists
-
-
-  // VL2 is a singleton
-  GPolyList ColonEmbedVectorLists(const VectorList& theVL1,
-                                  const VectorList& theVL2,
-                                  const GRingInfo& theGRI)
-  {
-    GPolyList FirstPart;
-    if (theVL1.empty())
-      return FirstPart;
-    const long NC = NumCompts(owner(theVL1[0]));
-    // const SparsePolyRing NewP=theGRI.myNewSPR();
-    FirstPart=EmbedVectorList(theVL1, theGRI);
-    GPoly GP1=EmbedVector(theVL2.front(), theGRI);
-    degree d=wdeg(theVL2.front());
-    GPoly GP2=EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, NC);
-    GP1.myAppendClear(GP2);
-    FirstPart.push_back(GP1);
-    return FirstPart;
-  } // ColonEmbedVectorLists
-
-
-  // PL2 is a singleton
-  GPolyList ColonEmbedPolyLists(const PolyList& thePL1,
-                                const PolyList& thePL2,
-                                const GRingInfo& theGRI)
-  {
-     GPolyList FirstPart;
-     if (thePL1.empty())  return FirstPart;
-     const SparsePolyRing NewP=theGRI.myNewSPR();
-     FirstPart=EmbedPolyList(thePL1, theGRI, 0);
-     GPoly GP1=EmbedPoly(thePL2.front(), theGRI, 0);
-     degree d=wdeg(thePL2.front());
-     GPoly GP2=EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, 1);
-     GP1.myAppendClear(GP2);
-     FirstPart.push_back(GP1);
-     return FirstPart;
-  } // ColonEmbedPolyLists
-
-
-  // Polys whose LPP has last var exponent bigger than ComponentsLimit disappear on DeEmbedding
-  VectorList DeEmbedPolyList(const PolyList& G,
-                             const GRingInfo& theGRI,
-                             const long ComponentsLimit)
-  {
-    VectorList outVL;
-    if (G.empty())  return outVL;
-    for (const RingElem& g: G)
-      if (theGRI.myComponent(LPP(g)) <= theGRI.myComponent(ComponentsLimit))
-        outVL.push_back(DeEmbedPoly(g, theGRI, ComponentsLimit));
-    return outVL;
   }
 
 
-  PolyList DeEmbedPolyListToPL(const PolyList& G,
-                               const GRingInfo& theGRI,
-                               const long ComponentsLimit)
+  GPolyList ColonEmbedVectorLists(const std::vector<ModuleElem>& VL,
+                                  const ModuleElem& v,
+                                  const GRingInfo& theGRI)
+  {
+    GPolyList FirstPart;
+    if (VL.empty())
+      return FirstPart;
+    const long NC = NumCompts(owner(VL[0]));
+    FirstPart = EmbedVectorList(VL, theGRI);
+    GPoly GP1 = EmbedVector(v, theGRI);
+    degree d = wdeg(v);
+    GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, NC);
+    GP1.myAppendClear(GP2);
+    FirstPart.push_back(GP1);
+    return FirstPart;
+  }
+
+
+  GPolyList ColonEmbedPolyLists(const std::vector<RingElem>& F,
+                                const RingElem& f,
+                                const GRingInfo& theGRI)
+  {
+     GPolyList FirstPart;
+     if (F.empty())  return FirstPart;
+     FirstPart = EmbedPolyList(F, theGRI, 0);
+     GPoly GP1 = EmbedPoly(f, theGRI, 0);
+     degree d = wdeg(f);
+     GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, 1);
+     GP1.myAppendClear(GP2);
+     FirstPart.push_back(GP1);
+     return FirstPart;
+  }
+
+
+  // Polys whose LPP has last var exponent bigger than ComponentsLimit disappear on DeEmbedding
+  std::vector<ModuleElem> DeEmbedPolyList(const std::vector<RingElem>& G,
+                                          const GRingInfo& theGRI,
+                                          const long ComponentsLimit)
+  {
+    std::vector<ModuleElem> G_out;
+    if (G.empty())  return G_out;
+    G_out.reserve(len(G));
+    for (const RingElem& g: G)
+      if (theGRI.myComponent(LPP(g)) <= theGRI.myComponent(ComponentsLimit))
+        G_out.push_back(DeEmbedPoly(g, theGRI, ComponentsLimit));
+    return G_out;
+  }
+
+
+  std::vector<RingElem> DeEmbedPolyListToPL(const std::vector<RingElem>& G,
+                                            const GRingInfo& theGRI,
+                                            const long ComponentsLimit)
   {
     VerboseLog VERBOSE("DeEmbedPolyListToPL");
-    PolyList outPL;
-    if (G.empty())  return outPL;
+    std::vector<RingElem> G_out;
+    if (G.empty())  return G_out;
+    G_out.reserve(len(G));
     for (const RingElem& g: G)
       if (theGRI.myComponent(LPP(g)) <= theGRI.myComponent(ComponentsLimit))
       {
         VERBOSE(100) << "LPP(g) = " << LPP(g) << std::endl; /////////////////
-        outPL.push_back(theGRI.myNewP2OldP()(g));
+        G_out.push_back(theGRI.myNewP2OldP()(g));
         // if ( IsConstant(outPL.last()) ) // redmine #1647 ////' doesn't happen
         // {
         //   outPL.clear();
@@ -1165,7 +1164,7 @@ Is is here only for completeness/debug purposes.
         //   break;
         // }
       }
-    return outPL;
+    return G_out;
   }
 
 

--- a/src/AlgebraicCore/TmpGReductor.C
+++ b/src/AlgebraicCore/TmpGReductor.C
@@ -204,8 +204,7 @@ namespace CoCoA
   // This procedure may be substituted by a transform_if
   std::vector<RingElem> GReductor::myExportGBasis()
   {
-    std::vector<RingElem> GB;
-    GB.reserve(len(myGB));
+    std::vector<RingElem> GB;  GB.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsActive(*ptr))  GB.push_back(poly(*ptr));
     return GB;
@@ -214,8 +213,7 @@ namespace CoCoA
 
   std::vector<RingElem> GReductor::myExportMinGens()
   {
-    std::vector<RingElem> G;
-    G.reserve(len(myGB));
+    std::vector<RingElem> G;  G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsMinimalGen(*ptr))  G.push_back(poly(*ptr));
     return G;
@@ -262,8 +260,7 @@ namespace CoCoA
 
   std::vector<ModuleElem> GReductor::myExportGBasis_module()
   {
-    std::vector<ModuleElem>  G;
-    G.reserve(len(myGB));
+    std::vector<ModuleElem> G;  G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsActive(*ptr))
         G.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
@@ -273,8 +270,7 @@ namespace CoCoA
 
   std::vector<ModuleElem> GReductor::myExportMinGens_module()
   {
-    std::vector<ModuleElem>  G;
-    G.reserve(len(myGB));
+    std::vector<ModuleElem> G;  G.reserve(len(myGB));
     for (const auto& ptr: myGB)
       if (IsMinimalGen(*ptr))
         G.push_back(DeEmbedPoly(poly(*ptr), myGRingInfoValue));
@@ -1078,15 +1074,14 @@ Is is here only for completeness/debug purposes.
   }
 
 
-  GPolyList IntEmbedVectorLists(const std::vector<ModuleElem>& theVL1,
-                                const std::vector<ModuleElem>& theVL2,
+  GPolyList IntEmbedVectorLists(const std::vector<ModuleElem>& G1,
+                                const std::vector<ModuleElem>& G2,
                                 const GRingInfo& theGRI)
   {
-    const long NC = NumCompts(owner(theVL1[0]));
-    //const SparsePolyRing NewP=theGRI.myNewSPR();
-    GPolyList FirstPart=EmbedVectorList(theVL1, theGRI);
-    GPolyList SecondPart=EmbedVectorList(theVL2, theGRI);
-    GPolyList ThirdPart=EmbedVectorList(theVL2, theGRI, NC);
+    const long NC = NumCompts(owner(G1[0]));
+    GPolyList FirstPart = EmbedVectorList(G1, theGRI);
+    GPolyList SecondPart = EmbedVectorList(G2, theGRI);
+    GPolyList ThirdPart = EmbedVectorList(G2, theGRI, NC);
     GPolyList::iterator it1=ThirdPart.begin();
     for (GPolyList::iterator it=SecondPart.begin();it!=SecondPart.end();++it,++it1)
       (*it).myAppendClear(*it1);
@@ -1100,29 +1095,25 @@ Is is here only for completeness/debug purposes.
                                   const GRingInfo& theGRI)
   {
     GPolyList FirstPart;
-    if (VL.empty())
-      return FirstPart;
-    const long NC = NumCompts(owner(VL[0]));
+    if (VL.empty())  return FirstPart;
     FirstPart = EmbedVectorList(VL, theGRI);
     GPoly GP1 = EmbedVector(v, theGRI);
-    degree d = wdeg(v);
-    GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, NC);
+    GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, wdeg(v), NumCompts(owner(v)));
     GP1.myAppendClear(GP2);
     FirstPart.push_back(GP1);
     return FirstPart;
   }
 
 
-  GPolyList ColonEmbedPolyLists(const std::vector<RingElem>& F,
+  GPolyList ColonEmbedPolyLists(const std::vector<RingElem>& G,
                                 const RingElem& f,
                                 const GRingInfo& theGRI)
   {
      GPolyList FirstPart;
-     if (F.empty())  return FirstPart;
-     FirstPart = EmbedPolyList(F, theGRI, 0);
+     if (G.empty())  return FirstPart;
+     FirstPart = EmbedPolyList(G, theGRI, 0);
      GPoly GP1 = EmbedPoly(f, theGRI, 0);
-     degree d = wdeg(f);
-     GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, d, 1);
+     GPoly GP2 = EmbedPoly(one(theGRI.myOldSPR()), theGRI, wdeg(f), 1);
      GP1.myAppendClear(GP2);
      FirstPart.push_back(GP1);
      return FirstPart;


### PR DESCRIPTION
Along this line changed "PolyList" and "VectorList" into the actual type: vector<RingElem> and vector<ModuleElem> to emphasize the difference between actual "list" (GPolyList) and vectors.
Changed ColonEmbedPolyLists: now takes a RingElem or ModuleElem (used to take a vector with a single element)