### PR TITLE
Improve err mesg when var was not assigned but has same name as a global

### DIFF
--- a/src/CoCoA-5/Interpreter.C
+++ b/src/CoCoA-5/Interpreter.C
@@ -1343,7 +1343,7 @@ string VariableNotFoundException::errorMessage(const string &varName, int arity,
 	bool thereIsAnExactMatch=false;
 	env->collectSimilarlyNamedIdentifiers(varName, arity, NearMatches, thereIsAnExactMatch);
 	if (thereIsAnExactMatch)
-		return message+", but there is one in an outside scope.  You're probably missing an import statement";
+		return message+", but there is one in an outside scope.  Perhaps you forgot to assign to it, or you forgot an import statement?";
 	const int size = NearMatches.size();
 	if (size==0)
 		return message;


### PR DESCRIPTION
Minor change.  I hope it makes more sense now.