### PR TITLE
Remove obsolete exception spec from debug_new.C

### DIFF
--- a/src/AlgebraicCore/debug_new.C
+++ b/src/AlgebraicCore/debug_new.C
@@ -205,10 +205,6 @@ namespace debug_new
 using namespace debug_new;
 
 void* operator new(size_t sz)
-#if __cplusplus < 201100L
-  // C++98 requires this exception specification; C++11 rejects it
-  throw (std::bad_alloc)
-#endif
 {
   if (sz > MAX_ALLOC) throw std::bad_alloc();
   ++NUM_NEW;


### PR DESCRIPTION
An exception specification was needed for C++98 compatibility; it was already rejected by C++11.  Anyway, `debug_new.C` is largely irrelevant given that `valgrind` works much better.
Is there any case for keeping `debug_new.C` any longer?
