### PR TITLE
Env var PKGCONF in configure script; added new check to gmp-find-hdr

### DIFF
--- a/configuration/gmp-find-hdr.sh
+++ b/configuration/gmp-find-hdr.sh
@@ -11,6 +11,17 @@ then
   exit 1
 fi
 
+# Check that path ends with libgmp.*  (simple rather than rigorous)
+case `basename "$1"` in
+    libgmp.*)
+	: # OK what we expected
+	;;
+    *)
+	echo "ERROR: path does not end with libgmp.*   $SCRIPT_NAME"   > /dev/stderr
+	exit 1
+	;;
+esac
+
 GMP_LIB="$1"
 
 

--- a/configure
+++ b/configure
@@ -346,6 +346,16 @@ then
 fi
 
 #############################################################################
+# Set env variable PKGCONF:  pkgconf (NEW)  or pkg-config (OLD)
+# Used by scripts in directory configuration/  to find installed libraries.
+
+export PKGCONF="pkg-config"
+if command -v pkgconf  >/dev/null  2>&1
+then
+   PKGCONF="pkgconf"
+fi
+
+#############################################################################
 # Find directory of this script (taken from link below)
 # http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
 


### PR DESCRIPTION
Added env var `PKGCONF` to `configure`: set to `pkgconf` if that exists on system, o/w set to `pkg-config` (whether that prog exists or not!)  No scripts use `$PKGCONF` currently.  Annoyingly `pkgconf` does not know about `libgmp` on my Ubuntu system... maybe because I installed it manually?
Added extra arg check to `gmp-find-hdr.sh`.
