### PR TITLE
Jaa/remove auto ptr

### DIFF
--- a/src/AlgebraicCore/DistrMPolyClean.C
+++ b/src/AlgebraicCore/DistrMPolyClean.C
@@ -338,65 +338,6 @@ namespace CoCoA
   }                                                 //???
 
 
-//   void DistrMPolyClean::myWeylAddMulSummand(const summand* s, const DistrMPolyClean& g, bool SkipLMg)
-//   {
-//     CoCoA_ASSERT(IsCompatible(*this, g));
-
-//     //    const PPOrdering& ord = ordering(myPPM);
-//     const ring& R = myCoeffRing;
-//     const size_t nvars = NumIndets(myPPM);
-// //???    clog << "AddMul: Doing funny product of the following two polys" << std::endl;
-// //???    output(clog, g);
-// //???    CoCoA_ASSERT(myRefCount == 1);
-//     //???    MakeWritable(f);
-
-//     const summand* g_term = g.mySummands;
-//     if (SkipLMg)    g_term = g_term->myNext;
-// //???    summand** f_prev = &mySummands;
-// //???    summand*  f_term = *f_prev;
-
-//     DistrMPolyClean ppg = g;
-//     vector<long> expv(nvars);
-//     myPPM->myExponents(expv, raw(s->myPP));
-// //???    clog << "expv: "; for (int i=0; i<myNumIndets;++i) clog << expv[i] << "  "; clog << std::endl;
-//     for (size_t indet = nvars/2; indet < nvars; ++indet)
-//     {
-//       long n = expv[indet];
-//       if (n == 0) continue;
-// //???      clog << "AddMul: doing D variable with index " << indet - myNumIndets/2 << std::endl;
-//       DistrMPolyClean der = ppg;
-
-// //???      ppg *= IndetPower(myPPM, indet, n);
-//       ppg.myMulByPP(raw(IndetPower(myPPM, indet, n)));
-// //      mul(raw(ppg), raw(ppg), raw(IndetPower(indet, n)));
-
-//       for (long i=1; i <= n; ++i)
-//       {
-//         deriv(der, der, indet-nvars/2);
-// //???        deriv(raw(der), raw(der), indet-nvars/2);
-// //???        clog << "der(" << i << ")="; output(clog, raw(der)); clog << std::endl;
-
-// //        ppg += binomial(n, i)*der*IndetPower(myPPM, indet, n-i); // *IndetPower(myPPM, h, 2*i); // for homog case
-//         auto_ptr<summand> jaa(new summand(myCoeffRing, myPPM));
-//         R->myAssign(raw(jaa->myCoeff), binomial(n, i));
-//         myPPM->myMulIndetPower(raw(jaa->myPP), indet, n-i);
-// // if (HOMOG_CASE)        myPPM->mul(jaa->myPP, jaa->myPP, IndetPower(myPPM, h, 2*i));
-//         ppg.myAddMulSummand(jaa.get(), der, false);
-//       }
-//     }
-//     { // f *= indet^deg(pp, indet); for the early vars
-//       for (size_t indet = nvars/2; indet < nvars; ++indet)
-//         expv[indet] = 0;
-//       auto_ptr<summand> jaa(new summand(myCoeffRing, myPPM));
-//       R->myAssign(raw(jaa->myCoeff), raw(s->myCoeff));
-//       myPPM->myAssign(raw(jaa->myPP), expv);
-//       myAddMulSummand(jaa.get(), ppg, false);
-//     }
-//   }
-
-
-
-
   void DistrMPolyClean::myReductionStep(const DistrMPolyClean& g)
   {
     CoCoA_ASSERT(&g!=this);

--- a/src/AlgebraicCore/DistrMPolyInlPP.C
+++ b/src/AlgebraicCore/DistrMPolyInlPP.C
@@ -904,7 +904,6 @@ namespace CoCoA
     APs.myRenew();
     myCoeffRing->myAssign(APs->myCoeff, (g.mySummands)->myCoeff);
     myOrdvArith->myAssign(APs->myOrdv, (g.mySummands)->myOrdv);
-    //    auto_ptr<summand> s(myCopySummand(g.mySummands));
     int CMP;
 
     while (f_smnd != nullptr &&

--- a/src/AlgebraicCore/ReductionCog.C
+++ b/src/AlgebraicCore/ReductionCog.C
@@ -27,10 +27,6 @@
 //using std::size_t;
 #include <iostream>
 //using std::ostream;
-#include <memory>
-//using std::auto_ptr;
-//#include <vector>
-//using std::vector;
 
 
 namespace CoCoA

--- a/src/AlgebraicCore/SparsePolyOps-hilbert.C
+++ b/src/AlgebraicCore/SparsePolyOps-hilbert.C
@@ -45,9 +45,6 @@
 
 #include <vector>
 using std::vector;
-// No longer needed: unique_ptr (was auto_ptr)
-// #include <memory>
-// using std::unique_ptr;
 
 namespace CoCoA
 {

--- a/src/AlgebraicCore/debug_new.C
+++ b/src/AlgebraicCore/debug_new.C
@@ -205,10 +205,6 @@ namespace debug_new
 using namespace debug_new;
 
 void* operator new(size_t sz)
-#if __cplusplus < 201100L
-  // C++98 requires this exception specification; C++11 rejects it
-  throw (std::bad_alloc)
-#endif
 {
   if (sz > MAX_ALLOC) throw std::bad_alloc();
   ++NUM_NEW;

--- a/src/server/GlobalIO.C
+++ b/src/server/GlobalIO.C
@@ -126,13 +126,12 @@ namespace CoCoA
 
 // As recommended in Meyers's book I have put the globals in an anonymous
 // namespace.  I chose to use plain pointers for the global variables
-// ``InPtr``, ``OutPtr``, ``ErrPtr`` and ``LogPtr``; references are unsuitable because
-// they cannot be reseated in C++, and ``auto_ptr`` is unsuitable because
-// we do not want to own the streams.  I do not believe that there can be
-// problems with race-conditions when these four global variables are
-// initialized since we use only the addresses of ``std::cin``, etc.
-// However, there could be race-condition problems with subsequent
-// changes to the values.
+// ``InPtr``, ``OutPtr``, ``ErrPtr`` and ``LogPtr``; references are unsuitable
+// because they cannot be reseated in C++, and ``shared_ptr`` is probably not
+// suitable.   I do not believe that there can be problems with race-conditions
+// when these four global variables are initialized since we use only the
+// addresses of ``std::cin``, etc.  However, there could be race-condition
+// problems with subsequent changes to the values -- who would do that?
 
 
 // It is tempting to make these simple functions into inline functions,


### PR DESCRIPTION
Just tidying up.  I noticed that `auto_ptr` is removed from C++17; we removed it from our code some time ago, so there is no point in mentioning it in the comments.
