### PR TITLE
Migrate to $PKGCONF variable and fix duplicate GMP findings

### DIFF
--- a/configuration/gmp-find-hdr.sh
+++ b/configuration/gmp-find-hdr.sh
@@ -42,7 +42,7 @@ then
   GMP_INC_DIR="$GMP_LIB_DIR_DIR"
 else
   # GMP is installed -- have to check two possible locations for the header file
-  GMP_INC_DIR1="$(pkg-config --variable=includedir gmp 2>/dev/null)"
+  GMP_INC_DIR1="$($PKGCONF --variable=includedir gmp 2>/dev/null)"
   GMP_INC_DIR2="$GMP_LIB_DIR_DIR"/include
   GMP_INC_DIR3="$GMP_LIB_DIR_DIR_DIR/include"
   GMP_INC_DIR4="$GMP_LIB_DIR_DIR_DIR/include/$PLATFORM"

--- a/configuration/gmp-find-lib.sh
+++ b/configuration/gmp-find-lib.sh
@@ -33,19 +33,25 @@ fi
 ARCH=$(uname -m)      #so far seen:  x86_64, aarch64, i686, i386
 
 
-STD_GMP_LIBDIRS="/usr/local/lib  /usr/lib  /usr/lib/$ARCH-linux-gnu  /usr/lib64
-                 /usr/lib32  /usr/lib/i386-linux-gnu  /opt/homebrew/lib
-                 /opt/local/lib  /sw/lib  /usr/sfw/lib"
-
-# Also try pkg-config
-if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists gmp; then
-    STD_GMP_LIBDIRS="$(pkg-config --variable=libdir gmp 2>/dev/null) $STD_GMP_LIBDIRS"
+# First try pkg-config and then add other "potentially missed" default places
+PKG_GMP_DIR=""
+if command -v "$PKGCONF" >/dev/null 2>&1 && "$PKGCONF" --exists gmp; then
+    PKG_GMP_DIR="$($PKGCONF --variable=libdir gmp 2>/dev/null)"
 fi
+GMP_LIBDIRS="$PKG_GMP_DIR"
+
+for dir in /usr/local/lib  /usr/lib  /usr/lib/$ARCH-linux-gnu  /usr/lib64 \
+           /usr/lib32  /usr/lib/i386-linux-gnu  /opt/homebrew/lib \
+           /opt/local/lib  /sw/lib  /usr/sfw/lib
+do
+    [ "$dir" != "$PKG_GMP_DIR" ] && GMP_LIBDIRS="$GMP_LIBDIRS $dir"
+done
+
 
 LIBGMPPATHS=libgmp-paths
 /bin/rm -rf "$LIBGMPPATHS"
 COUNTER=0
-for dir in $STD_GMP_LIBDIRS
+for dir in $GMP_LIBDIRS
 do
   if [ -d "$dir" ]
   then
@@ -59,7 +65,7 @@ done
 if [ "$COUNTER" -eq 0 ]
 then
   # Did not find any plausible GMP installation, so return empty handed.
-    echo "ERROR: No GMP installation found; looked inside $STD_GMP_LIBDIRS   $SCRIPT_NAME"   > /dev/stderr
+    echo "ERROR: No GMP installation found; looked inside $GMP_LIBDIRS   $SCRIPT_NAME"   > /dev/stderr
     echo ">>>>> HINT:  try installing the linux package libgmp-dev  <<<<<"  >> /dev/stderr
     echo ">>>>> HINT:  or get sources from https://www.gmplib.org/  <<<<<"  >> /dev/stderr
 #    /bin/rm -f "$LIBGMPPATHS"  # never created the file -- no need to remove it!

--- a/configuration/gmp-find-lib.sh
+++ b/configuration/gmp-find-lib.sh
@@ -35,7 +35,7 @@ ARCH=$(uname -m)      #so far seen:  x86_64, aarch64, i686, i386
 
 # First try pkg-config and then add other "potentially missed" default places
 PKG_GMP_DIR=""
-if command -v "$PKGCONF" >/dev/null 2>&1 && "$PKGCONF" --exists gmp; then
+if "$PKGCONF" --exists gmp >/dev/null 2>&1; then
     PKG_GMP_DIR="$($PKGCONF --variable=libdir gmp 2>/dev/null)"
 fi
 GMP_LIBDIRS="$PKG_GMP_DIR"

--- a/configure
+++ b/configure
@@ -1351,12 +1351,9 @@ if [ $HAVE_GSL = "yes" ]
 then
 ####  echo "GSL_INC_DIR=\"$GSL_INC_DIR\""                     >> "$CONFIG_TMP"
 ####  echo "GSL_INCLUDE=-I \$(GSL_INC_DIR)"                   >> "$CONFIG_TMP"
-  command -v pkgconf > /dev/null 2>&1
-  if [ $? -eq 0 ]
+  if "$PKGCONF" --exists gsl 2>/dev/null
   then
-      # !!! THIS BRANCH IS UNTESTED !!!
-      # pkgconf assumes that gsl is system installed
-      GSL_LDLIBS=`pkgconf --libs gsl`
+      GSL_LDLIBS=$($PKGCONF --libs gsl)
       echo "GSL_LDLIBS=$GSL_LDLIBS"                           >> "$CONFIG_TMP"
   else
       echo "GSL_LDLIBS=-lgsl-symlink  -lgslcblas  -llapack"   >> "$CONFIG_TMP"


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/cocoa-official/CoCoALib/pull/122#issuecomment-4495651486 and migrates all `pkgconf` and `pkg-config` usages to the new `$PKGCONF` variable introduced in #122.
Also applies the suggested change from https://github.com/cocoa-official/CoCoALib/pull/125#discussion_r3272562781