### PR TITLE
Added new function DivExact

### DIFF
--- a/doc/txt/BigIntOps.txt
+++ b/doc/txt/BigIntOps.txt
@@ -1,5 +1,5 @@
       BigIntOps
-      Copyright (c)  2012,2014,2017,2023 John Abbott and Anna M. Bigatti
+      Copyright (c)  2012,2014,2017,2023,2026 John Abbott and Anna M. Bigatti
       GNU Free Documentation License, Version 1.2
 %!includeconf: ../aux-txt2tags/config.t2t
       TeXTitle{BigIntOps}{John Abbott}
@@ -59,7 +59,7 @@ Only for [[BigInt]]
  - ``+``    the sum
  - ``-``    the difference
  - ``*``    the product
- - ``/``    integer quotient (**truncated** "towards zero")
+ - ``/``    integer quotient (**truncated** "towards zero"); **see also ``DivExact''** (below)
  - ``%``    remainder (same sign as LHS arg if non-zero); satisfies a = b*(a/b)+(a%b); **see also ``LeastNNegRemainder`` and ``SymmRemainder``** (below)
 
 
@@ -104,6 +104,7 @@ The arguments of the functions below may be either a machine integer or a ``BigI
 
 - ``abs(n)``         -- the absolute value of ``n``
 - ``sign(n)``        -- returns ``int`` with value  -1 if ``n<0``, 0 if ``n==0``, and +1 if ``n>0``
+- ``DivExact(n,m)``  -- returns ``n/m`` if the division is exact; it is not documented what is returned if the division is not exact; for larger inputs it is faster than ``n/m``
 - ``LeastNNegRemainder(x,m)``  -- least non-negative remainder; throws ``ERR::DivByZero`` if ``m==0``; result is ``long`` if ``m`` is a machine integer
 - ``SymmRemainder(x,m)``  -- symmetric remainder; throws ``ERR::DivByZero`` if ``m==0``; result is ``long`` if ``m`` is a machine integer
 - ``log(n)``         -- natural logarithm of ``n`` (as a ``double``); error if `` n <= 0``

--- a/include/CoCoA/BigIntOps.H
+++ b/include/CoCoA/BigIntOps.H
@@ -52,6 +52,9 @@ namespace CoCoA
   BigInt operator/(const BigInt& N1, const MachineInt& n2);
   BigInt operator/(const MachineInt& n1, const BigInt& N2);
 
+  BigInt DivExact(const BigInt& N1, const BigInt& N2);
+  BigInt DivExact(const BigInt& N1, const MachineInt& n2);
+
   BigInt operator%(const BigInt& N1, const BigInt& N2);
   long operator%(const BigInt& N1, const MachineInt& n2);
   BigInt operator%(const MachineInt& n1, const BigInt& N2);

--- a/src/AlgebraicCore/BigIntOps.C
+++ b/src/AlgebraicCore/BigIntOps.C
@@ -197,19 +197,21 @@ namespace CoCoA
   {
     if (IsZero(N2))
       CoCoA_THROW_ERROR1(ERR::DivByZero);
-    BigInt ans;
-    mpz_divexact(mpzref(ans), mpzref(N1), mpzref(N2));
-    return ans;
+    BigInt q;
+    mpz_divexact(mpzref(q), mpzref(N1), mpzref(N2));
+    CoCoA_ASSERT(N1 == q*N2);
+    return q;
   }
   
   BigInt DivExact(const BigInt& N1, const MachineInt& n2)
   {
     if (IsZero(n2))
       CoCoA_THROW_ERROR1(ERR::DivByZero);
-    BigInt ans;
-    mpz_divexact_ui(mpzref(ans), mpzref(N1), uabs(n2));
-    if (IsNegative(n2))  negate(ans);
-    return ans;
+    BigInt q;
+    mpz_divexact_ui(mpzref(q), mpzref(N1), uabs(n2));
+    if (IsNegative(n2))  negate(q);
+    CoCoA_ASSERT(N1 == q*n2);
+    return q;
   }
 
 

--- a/src/AlgebraicCore/BigIntOps.C
+++ b/src/AlgebraicCore/BigIntOps.C
@@ -193,6 +193,26 @@ namespace CoCoA
   }
 
 
+  BigInt DivExact(const BigInt& N1, const BigInt& N2)
+  {
+    if (IsZero(N2))
+      CoCoA_THROW_ERROR1(ERR::DivByZero);
+    BigInt ans;
+    mpz_divexact(mpzref(ans), mpzref(N1), mpzref(N2));
+    return ans;
+  }
+  
+  BigInt DivExact(const BigInt& N1, const MachineInt& n2)
+  {
+    if (IsZero(n2))
+      CoCoA_THROW_ERROR1(ERR::DivByZero);
+    BigInt ans;
+    mpz_divexact_ui(mpzref(ans), mpzref(N1), uabs(n2));
+    if (IsNegative(n2))  negate(ans);
+    return ans;
+  }
+
+
   BigInt operator%(const BigInt& N1, const BigInt& N2)
   {
     if (IsZero(N2))

--- a/src/CoCoA-5/BuiltInOneLiners-CoCoALib.C
+++ b/src/CoCoA-5/BuiltInOneLiners-CoCoALib.C
@@ -1,4 +1,4 @@
-//   Copyright (c) 2012-2016,2022  John Abbott, Anna M. Bigatti
+//   Copyright (c) 2012-2016,2022,2026  John Abbott, Anna M. Bigatti
 //   Original author: 2012 Giovanni Lagorio.
 //
 //   This file is part of the source of CoCoALib, the CoCoA Library.
@@ -40,6 +40,7 @@ DECLARE_COCOALIB_FUNCTION1(NextProbPrime, INT) // AMB
 DECLARE_COCOALIB_FUNCTION1(PrevProbPrime, INT) // JAA
 DECLARE_COCOALIB_FUNCTION1(SmallestNonDivisor, INT) // JAA
 DECLARE_COCOALIB_FUNCTION2(FactorMultiplicity, INT, INT) // JAA
+DECLARE_COCOALIB_FUNCTION2(DivExact, INT, INT) // JAA 2026-05-20
 DECLARE_COCOALIB_FUNCTION2(RoundDiv, INT, INT) // JAA
 DECLARE_COCOALIB_FUNCTION2(FloorRoot, INT, INT) // AMB
 DECLARE_COCOALIB_FUNCTION3(PowerMod, INT, INT, INT)

--- a/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
+++ b/src/CoCoA-5/CoCoAManual/CoCoAHelp.xml
@@ -5267,6 +5267,31 @@ record[
 </command>
 <!-- ===  COMMAND  =============================================== -->
 <command>
+  <title>DivExact</title>
+  <short_description>exact division</short_description>
+<syntax>
+DivExact(X: <type>INT</type>, Y: <type>INT</type>): <rtn>INT</rtn>
+</syntax>
+<description>
+This function computes the quotient <tt>X/Y</tt> provided that <tt>Y</tt> divides <tt>X</tt>
+exactly; if the division is not exact then it is undocumented what result is
+returned.  For larger arguments this function is faster than computing <tt>X/Y</tt>.
+<example>
+/**/  DivExact(factorial(1000), factorial(998));
+999000
+</example>
+</description>
+<seealso>
+  <see>div</see>
+  <see>mod</see>
+</seealso>
+<keys>
+  <key>remainder</key>
+  <key>exact division</key>
+</keys>
+</command>
+<!-- ===  COMMAND  =============================================== -->
+<command>
   <title>domain</title>
   <short_description>domain of a homomorphism</short_description>
 <syntax>

--- a/src/tests/test-BigInt1.C
+++ b/src/tests/test-BigInt1.C
@@ -140,6 +140,19 @@ namespace CoCoA
           CoCoA_ASSERT_ALWAYS(i/j == BigInt(i)/BigInt(j));
         }
       }
+
+    // Test DivExact
+    for (int i = -LIMIT; i <= LIMIT; ++i)
+    {
+      const BigInt I(i);
+      for (int j = -LIMIT; j <= LIMIT; ++j)
+      {
+        if (j == 0)  continue;
+        const BigInt prod = I*j;
+        CoCoA_ASSERT_ALWAYS(DivExact(prod, j) == I);
+        CoCoA_ASSERT_ALWAYS(DivExact(prod, BigInt(j)) == I);
+      }
+    }
   }
 
 } // end of namespace CoCoA


### PR DESCRIPTION
New function `DivExact(A,B)`, just integers at the moment.  It assumes that `B` divides `A` exactly, and in this case computes the result faster than doing `A/B`.  Later (much later) it may be extended to polynomials too.
Includes doc & CoCoALib test.