### PR TITLE
New class ProdBigInt; changed name of fn to get result from SumBigInt and SumBigRat

### DIFF
--- a/doc/txt/BigIntOps.txt
+++ b/doc/txt/BigIntOps.txt
@@ -150,8 +150,23 @@ This class is **not thread-safe.**
 Let ``N`` be an integer, and ``SBI`` be a ``SumBigInt`` object.
 - ``SumBigInt()``   -- create a ``SumBigInt`` object with value 0
 - ``SBI += N``      -- accumulate ``N`` (big or small) into the sum inside ``SBI``
-- ``total(SBI)``    -- return the sum of the values accumulated
-- ``SBI.myTotal()`` -- equiv to ``SBI.myTotal()``
+- ``result(SBI)``    -- return the sum of the values accumulated; this operation may take some time!
+- ``SBI.myResult()`` -- equiv to ``result(SBI)``
+-
+
+BUG: Currently there is no ``operator-=``; should there be?
+
+
+==== Product ====
+
+To multiply many ``BigInt`` integers use a ``ProdBigInt`` object.
+This class is **not thread-safe.**
+
+Let ``N`` be an integer, and ``PBI`` be a ``ProdBigInt`` object.
+- ``ProdBigInt()``   -- create a ``ProdBigInt`` object with value 1
+- ``PBI *= N``       -- multiply the product inside ``PBI`` by ``N`` (big or small)
+- ``result(PBI)``    -- return the product of the values accumulated; this operation make take some time!
+- ``PBI.myResult()`` -- equiv to ``result(PBI)``
 -
 
 BUG: Currently there is no ``operator-=``; should there be?

--- a/doc/txt/BigRatOps.txt
+++ b/doc/txt/BigRatOps.txt
@@ -118,11 +118,11 @@ To sum many rationals use a ``SumBigRat`` object.
 This class is **not thread-safe.**
 
 Let ``n`` be an integer, ``q`` be a ``BigRat``, and ``SBR`` be a ``SumBigRat`` object.
-- ``SumBigRat()``   -- create a ``SumBigRat`` object with value 0
-- ``SBR += n``      -- accumulate ``n`` into the sum inside ``SBR``
-- ``SBR += q``      -- accumulate ``q`` into the sum inside ``SBR``
-- ``total(SBR)``    -- return the sum of the values accumulated
-- ``SBR.myTotal()`` -- same as ``total(SBR)``
+- ``SumBigRat()``    -- create a ``SumBigRat`` object with value 0
+- ``SBR += n``       -- accumulate ``n`` into the sum inside ``SBR``
+- ``SBR += q``       -- accumulate ``q`` into the sum inside ``SBR``
+- ``result(SBR)``    -- return the sum of the values accumulated; this operation may take some time!
+- ``SBR.myResult()`` -- same as ``result(SBR)``
 -
 
 Currently there is no ``operator-=``; should there be?

--- a/examples/ex-SumBigRat.C
+++ b/examples/ex-SumBigRat.C
@@ -36,14 +36,14 @@ namespace CoCoA
       ZZsum += -i;
       ZZsum += i;
     }
-    if (ZZsum.myTotal() != power(2,10000))
+    if (result(ZZsum) != power(2,10000))
       CoCoA_THROW_ERROR2(ERR::AssertFail, "ZZsum is wrong");
 
     // Sum the reciprocals of the first few primes
-    SumBigRat SUM;
+    SumBigRat QQsum;
     for (PrimeSeq Pseq; *Pseq < 1000000; ++Pseq)
-      SUM += BigRat(1,*Pseq);
-    cout << FloatStr(SUM.myTotal()) << endl;
+      QQsum += BigRat(1,*Pseq);
+    cout << FloatStr(result(QQsum)) << endl;
   }
 
 } // end of namespace CoCoA

--- a/include/CoCoA/BigIntOps.H
+++ b/include/CoCoA/BigIntOps.H
@@ -76,6 +76,7 @@ namespace CoCoA
   long SmallPower(const MachineInt& base, const MachineInt& exponent); ///< base^exponent (assuming it fits into a long)
 
 
+  //---------------------------------
   class SumBigInt
   {
   public:
@@ -100,7 +101,7 @@ namespace CoCoA
         return *this;
       }
 ///    void myAdd(const BigInt& N); // threadsafe version of op+=
-    const BigInt& myTotal() const;
+    const BigInt& myResult() const;
   private: // data members
 ///    std::mutex myMutex; // causes too much complication :-(
     mutable BigInt myPositiveSum;
@@ -108,8 +109,40 @@ namespace CoCoA
     friend std::ostream& operator<<(std::ostream& out, const SumBigInt& S);
   };
 
-  inline const BigInt& total(const SumBigInt& S)  { return S.myTotal(); }
+  inline const BigInt& result(const SumBigInt& S)  { return S.myResult(); }
   std::ostream& operator<<(std::ostream& out, const SumBigInt& S);
+
+
+  // ---------------------------------
+  class ProdBigInt
+  {
+  public:
+    ProdBigInt(): myFactors(1,BigInt(1)) { /* myFactors.reserve(10); */ };
+    ProdBigInt(const ProdBigInt&) = default;
+    ProdBigInt(ProdBigInt&&) = default;
+    ProdBigInt& operator=(const ProdBigInt&) = default;
+    ProdBigInt& operator=(ProdBigInt&&) = default;
+    ~ProdBigInt() = default;
+    ProdBigInt& operator*=(const MachineInt& n) // NOT THREADSAFE!
+      {
+        if (IsNegative(n))  return myMul(AsSignedLong(n));
+        else return myMul(AsUnsignedLong(n));
+      }
+    ProdBigInt& operator*=(const BigInt& N); // NOT THREADSAFE!
+    const BigInt& myResult() const;
+  private: // data members
+    mutable std::vector<BigInt> myFactors; // guaranteed to be non-empty; myFactors[0] == 0 iff prod is zero
+  private: // impl details
+    ProdBigInt& myMul(unsigned long n); // NOT THREADSAFE!
+    ProdBigInt& myMul(long n);          // NOT THREADSAFE!
+    void myNormalize(int i) /*(morally) const*/;
+    unsigned int myIndex(const BigInt& N) const;
+    friend std::ostream& operator<<(std::ostream& out, const ProdBigInt& P);
+  };
+
+  inline const BigInt& result(const ProdBigInt& S)  { return S.myResult(); }
+  std::ostream& operator<<(std::ostream& out, const ProdBigInt& P);
+
 
 
   // Efficient arithmetic procedures...

--- a/include/CoCoA/BigRatOps.H
+++ b/include/CoCoA/BigRatOps.H
@@ -83,7 +83,7 @@ namespace CoCoA
     SumBigRat& operator+=(const BigRat& Q); // NOT THREADSAFE
 ///    void myAdd(const BigInt& N); // threadsafe version of op+=
 ///    void myAdd(const BigRat& Q); // threadsafe version of op+=
-    BigRat myTotal() const;      // compute & return the total (not threadsafe)
+    BigRat myResult() const;      // compute & return the total (not threadsafe)
   private: // data members
 ///    std::mutex myMutex; // causes too much complication
     SumBigInt myBigIntPart;
@@ -94,8 +94,8 @@ namespace CoCoA
     friend std::ostream& operator<<(std::ostream& out, const SumBigRat& S);
   };
 
-  inline BigRat total(const SumBigRat& S)
-  { return S.myTotal(); }
+  inline BigRat result(const SumBigRat& S)
+  { return S.myResult(); }
 
   std::ostream& operator<<(std::ostream& out, const SumBigRat& S);
 

--- a/src/AlgebraicCore/BigIntOps.C
+++ b/src/AlgebraicCore/BigIntOps.C
@@ -449,7 +449,7 @@ namespace CoCoA
 //   }
 
 
-  const BigInt& SumBigInt::myTotal() const
+  const BigInt& SumBigInt::myResult() const
   {
 //???   std::lock_guard<std::mutex> lock(myMutex);
     if (IsZero(myNegativeSum))  return myPositiveSum;
@@ -466,6 +466,105 @@ namespace CoCoA
     if (!out)  return out;
     out << "SumBigInt(myNegativeSum=" << FloorLog2(S.myNegativeSum) << " bits, myPositiveSum=" << FloorLog2(S.myPositiveSum) << " bits)";
     return out;
+  }
+
+
+  //---------------------------------
+  // ProdBigInt mem fns
+
+    ProdBigInt& ProdBigInt::myMul(unsigned long n)   // NOT THREADSAFE!
+  {
+    if (IsZero(myFactors[0]))  return *this;
+    if (n == 0)  { myFactors[0] = 0; return *this; }
+    mpz_mul_ui(mpzref(myFactors[0]), mpzref(myFactors[0]), n); // myFactors[0] *= n;
+    myNormalize(0);
+    return *this;
+  }
+
+  ProdBigInt& ProdBigInt::myMul(long n)   // NOT THREADSAFE!
+  {
+    if (IsZero(myFactors[0]))  return *this;
+    if (n == 0)  { myFactors[0] = 0; return *this; }
+    mpz_mul_si(mpzref(myFactors[0]), mpzref(myFactors[0]), n); // myFactors[0] *= n;
+    myNormalize(0);
+    return *this;
+  }
+
+  ProdBigInt& ProdBigInt::operator*=(const BigInt& N)   // NOT THREADSAFE!
+  {
+    if (IsZero(myFactors[0]))  return *this;
+    if (IsZero(N))  { myFactors[0] = 0; return *this; }
+    const int i = myIndex(N);
+    if (i < len(myFactors))
+    {
+      myFactors[i] *= N;
+      myNormalize(i);
+      return *this;
+    }
+    myFactors.resize(i+1, BigInt(1));
+    myFactors[i] = N;
+    return *this;
+  }
+
+
+  const BigInt& ProdBigInt::myResult() const
+  {
+    if (IsZero(myFactors[0]))  return myFactors[0];
+//???   std::lock_guard<std::mutex> lock(myMutex);
+    BigInt prod(1);
+    for (BigInt& fac: myFactors)
+    {
+      prod *= fac;
+      fac = 1;
+    }
+    const int i = myIndex(prod);
+    if (i < len(myFactors))  myFactors[i] = prod;  // std::move ???
+    else myFactors.push_back(prod);
+    return myFactors[i];
+  }
+
+  unsigned int ProdBigInt::myIndex(const BigInt& N) const
+  {
+    // Assumes a factor of 4 between "bucket" sizes
+    CoCoA_ASSERT(!IsZero(N));
+    size_t sz = mpz_size(mpzref(N));
+    int i = 0;
+    while (sz >= 4)
+    {
+      sz /= 4;
+      ++i;
+    }
+    return i;
+  }
+
+  void ProdBigInt::myNormalize(int i) /*(morally) const*/
+  {
+    const unsigned int n = len(myFactors);
+    CoCoA_ASSERT(i < n);
+    for (unsigned int j=i; j < n-1; ++j)
+    {
+      if (myIndex(myFactors[j]) <= j)  return;
+      // Cascade
+      // if (mpz_size(mpzref(myFactors[j+1])) == 1)
+      // {
+      //  // avoid allocation & copying
+      //   swap(myFactors[j], myFactors[j+1]);
+      //   continue;
+      // }  
+      myFactors[j+1] *= myFactors[j];
+      myFactors[j] = 1;
+    }
+    if (myIndex(myFactors[n-1]) == n-1)  return;
+    myFactors.push_back(BigInt(1));
+    swap(myFactors[n-1], myFactors[n]);
+  }
+
+  std::ostream& operator<<(std::ostream& out, const ProdBigInt& P)
+  {
+    if (!out)  return out;
+    if (IsZero(P.myFactors[0]))
+      return out << "ProdBigInt(0)";
+    return out << "ProdBigInt(NumBuckets=" << len(P.myFactors) << ")";
   }
 
 

--- a/src/AlgebraicCore/BigRatOps.C
+++ b/src/AlgebraicCore/BigRatOps.C
@@ -284,7 +284,7 @@ namespace CoCoA
   }
 
 
-  BigRat SumBigRat::myTotal() const
+  BigRat SumBigRat::myResult() const
   {
 //???    //    std::scoped_lock lock(myMutex); // needs C++17
 //???    std::lock_guard<std::mutex> lock(myMutex); // cannot use auto :-(
@@ -294,13 +294,14 @@ namespace CoCoA
       sum += q;
       q = 0;
     }
+    const BigInt& N = result(myBigIntPart);  // reference is safe here
     if (IsZero(sum))
-      return BigRat(myBigIntPart.myTotal());
+      return BigRat(N);
 
     const std::size_t i = ourIndex(sum);
     if (i >= myGeobucket.size())  myGeobucket.resize(i+1);
     myGeobucket[i] = sum;
-    return sum + total(myBigIntPart);
+    return sum + N;
   }
 
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -7,7 +7,7 @@ CWD=src/tests/
 DEPEND_FILE=Makefile_dependencies
 
 TESTS=test-empty.C \
-      test-BigInt1.C  test-BigInt2.C  test-BigInt3.C \
+      test-BigInt1.C  test-BigInt2.C  test-BigInt3.C  test-BigInt4.C \
       test-BigRat1.C  test-BigRat2.C  test-BigRat3.C  test-BigRat4.C \
       test-bool3.C \
       test-exbugs.C  \

--- a/src/tests/test-BigInt4.C
+++ b/src/tests/test-BigInt4.C
@@ -1,0 +1,84 @@
+//   Copyright (c)  2026  John Abbott,  Anna M. Bigatti
+
+//   This file is part of the source of CoCoALib, the CoCoA Library.
+
+//   CoCoALib is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+
+//   CoCoALib is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+
+//   You should have received a copy of the GNU General Public License
+//   along with CoCoALib.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "CoCoA/BigIntOps.H"
+#include "CoCoA/BuildInfo.H"
+#include "CoCoA/GlobalManager.H"
+#include "CoCoA/convert.H"
+#include "CoCoA/error.H"
+
+#include <cstdlib>
+using std::abs;
+#include <iostream>
+using std::clog;
+using std::cerr;
+using std::endl;
+#include<limits>
+using std::numeric_limits;
+
+
+namespace CoCoA
+{
+
+  // test IsExactRoot
+  void program()
+  {
+    using std::abs;
+    // This test checks the classes SumBigInt and ProdBigInt.
+    GlobalManager CoCoAFoundations(UseGMPAllocator);
+
+    SumBigInt S;
+    const long n=1000;
+    for (int i=0; i <= n; ++i)
+      S += power(-1,i)*binomial(n,i);
+    CoCoA_ASSERT_ALWAYS(IsZero(result(S)));
+
+    ProdBigInt P;
+    for (int i=1; i <= n; ++i)
+      P *= i;
+    CoCoA_ASSERT_ALWAYS(result(P) == factorial(n));
+  }
+
+} // end of namespace CoCoA
+
+
+// Use main() to handle any uncaught exceptions and warn the user about them.
+int main()
+{
+  try
+  {
+    CoCoA::program();
+    return 0;
+  }
+  catch (const CoCoA::ErrorInfo& err)
+  {
+    cerr << "***ERROR***  UNCAUGHT CoCoA Error";
+    ANNOUNCE(cerr, err);
+  }
+  catch (const std::exception& exc)
+  {
+    cerr << "***ERROR***  UNCAUGHT std::exception: " << exc.what() << endl;
+  }
+  catch(...)
+  {
+    cerr << "***ERROR***  UNCAUGHT UNKNOWN EXCEPTION" << endl;
+  }
+
+  CoCoA::BuildInfo::PrintAll(cerr);
+  return 1;
+}


### PR DESCRIPTION
New class `ProdBigInt`: design inspired by that of `SumBigInt` (and `SumBigRat`).
Changed the name of the fn to get the result from these classes: now it is `result(...)`  used to be `total(...)`.
Sorry, this turned out to be bigger than expected.
