### PR TITLE
Jaa/clean crt mill my add info

### DIFF
--- a/doc/txt/NumTheory.txt
+++ b/doc/txt/NumTheory.txt
@@ -200,7 +200,7 @@ answer (assuming perfect bounds are known).  In practice, this means
 that **the methods always fail if the combined modulus is too small**.
 
 The constructors available are:
-- ``RatReconstructByContFrac()`` ctor for continued fraction method mill log-epsilon equal to 20
+- ``RatReconstructByContFrac()`` ctor for continued fraction method mill (with log-epsilon equal to 20 by default)
 - ``RatReconstructByContFrac(LogEps)`` ctor for continued fraction method mill with given log-epsilon (must be at least 3)
 - ``RatReconstructByLattice(SafetyFactor)`` ctor for lattice method mill with given ``SafetyFactor`` (0 --> use default)
 

--- a/src/AlgebraicCore/NumTheory-CRT.C
+++ b/src/AlgebraicCore/NumTheory-CRT.C
@@ -56,7 +56,7 @@ namespace CoCoA
     const long a = LeastNNegRemainder(myR,m);
     long k;
     if (m <= MaxSquarableInteger<long>())
-      k = SymmRemainder((r-a)*InvMod(myM,m),m); // if both (r-a) & InvMod(..) are LeastNNegRem then no overflow if m <= MaxSquarableInteger
+      k = SymmRemainder((r-a)*InvMod(myM,m),m); // if both r, a & InvMod(..) are LeastNNegRem then no overflow if m <= MaxSquarableInteger
     else
       k = SymmRemainder(BigInt(r-a)*InvMod(myM,m),m); // use BigInt to avoid possible overflow (don't care about speed)
     myR += k*myM;

--- a/src/AlgebraicCore/NumTheory-CRT.C
+++ b/src/AlgebraicCore/NumTheory-CRT.C
@@ -42,16 +42,17 @@ namespace CoCoA
 
   void CRTMill::myAddInfo(const MachineInt& res, const MachineInt& mod, CoprimeFlag check)
   {
+    // First check that mod >= 2, and (depending on CoprimeFlag) that it is coprime to product of all previous moduli,
     if (IsNegative(mod))  CoCoA_THROW_ERROR1(ERR::BadModulus);
     if (!IsSignedLong(mod) || !IsSignedLong(res))
       CoCoA_THROW_ERROR1(ERR::ArgTooBig);
     const long m = AsSignedLong(mod);
+    if (m == 1)  CoCoA_THROW_ERROR1(ERR::BadModulus);
     if (check == CheckCoprimality && gcd(m,myM) != 1)
       CoCoA_THROW_ERROR2(ERR::BadArg, "new modulus not coprime");
     CoCoA_ASSERT(IsCoprime(m,myM));
-    long r = uabs(res)%m;
-    if (r != 0 && IsNegative(res))  r = m-r;
-    const long a = myR%m;
+    const long r = (IsNegative(res)) ? (m-SymmRemainder(uabs(res),m)) : (SymmRemainder(uabs(res),m));
+    const long a = SymmRemainder(myR,m);
     long k;
     if (m <= MaxSquarableInteger<long>())
       k = SymmRemainder((r-a)*InvMod(myM,m),m); // if both (r-a) & InvMod(..) are SymmRem then can allow m <= 2*MaxSquarableInteger
@@ -65,8 +66,7 @@ namespace CoCoA
   // CoprimeFlag check disables the coprimeness safety check (to save time)
   void CRTMill::myAddInfo(const BigInt& r, const BigInt& m, CoprimeFlag check)
   {
-    if (IsOne(m))  return;
-    if (IsOne(m))  { if (!IsOne(myM))  CoCoA_THROW_ERROR1(ERR::BadModulus); return; }
+    if (m < 2)  CoCoA_THROW_ERROR1(ERR::BadModulus);
     if (check == CheckCoprimality && gcd(m,myM) != 1)
       CoCoA_THROW_ERROR2(ERR::BadArg, "new modulus not coprime");
     CoCoA_ASSERT(IsCoprime(m,myM));

--- a/src/AlgebraicCore/NumTheory-CRT.C
+++ b/src/AlgebraicCore/NumTheory-CRT.C
@@ -61,17 +61,17 @@ namespace CoCoA
     myM *= m;
   }
 
+  // modulus m MUST BE coprime to all previous moduli;
+  // CoprimeFlag check disables the coprimeness safety check (to save time)
   void CRTMill::myAddInfo(const BigInt& r, const BigInt& m, CoprimeFlag check)
   {
-//???JAA    CoCoA_ASSERT(m > 1);
-    if (IsOne(m))  return; //???JAA
+    if (IsOne(m))  return;
     if (IsOne(m))  { if (!IsOne(myM))  CoCoA_THROW_ERROR1(ERR::BadModulus); return; }
-    CoCoA_ASSERT((r < m) && (r > -m));
     if (check == CheckCoprimality && gcd(m,myM) != 1)
       CoCoA_THROW_ERROR2(ERR::BadArg, "new modulus not coprime");
     CoCoA_ASSERT(IsCoprime(m,myM));
     const BigInt a = myR%m;
-    const BigInt k = SymmRemainder((r-a)*InvMod(myM,m), m); ///???BUG/SLUG??? SymmRemainder(r-a,m) ???
+    const BigInt k = SymmRemainder(SymmRemainder(r-a,m)*InvMod(myM,m), m);
     myR += k*myM;
     myM *= m;
   }

--- a/src/AlgebraicCore/NumTheory-CRT.C
+++ b/src/AlgebraicCore/NumTheory-CRT.C
@@ -47,23 +47,22 @@ namespace CoCoA
     if (!IsSignedLong(mod) || !IsSignedLong(res))
       CoCoA_THROW_ERROR1(ERR::ArgTooBig);
     const long m = AsSignedLong(mod);
-    if (m == 1)  CoCoA_THROW_ERROR1(ERR::BadModulus);
+    if (m < 2)  CoCoA_THROW_ERROR1(ERR::BadModulus);  // require modulus >= 2
     if (check == CheckCoprimality && gcd(m,myM) != 1)
       CoCoA_THROW_ERROR2(ERR::BadArg, "new modulus not coprime");
     CoCoA_ASSERT(IsCoprime(m,myM));
-    const long r = (IsNegative(res)) ? (m-SymmRemainder(uabs(res),m)) : (SymmRemainder(uabs(res),m));
-    const long a = SymmRemainder(myR,m);
+    long r = uabs(res)%m;
+    if (r != 0 && IsNegative(res))  r = m-r;
+    const long a = LeastNNegRemainder(myR,m);
     long k;
     if (m <= MaxSquarableInteger<long>())
-      k = SymmRemainder((r-a)*InvMod(myM,m),m); // if both (r-a) & InvMod(..) are SymmRem then can allow m <= 2*MaxSquarableInteger
+      k = SymmRemainder((r-a)*InvMod(myM,m),m); // if both (r-a) & InvMod(..) are LeastNNegRem then no overflow if m <= MaxSquarableInteger
     else
       k = SymmRemainder(BigInt(r-a)*InvMod(myM,m),m); // use BigInt to avoid possible overflow (don't care about speed)
     myR += k*myM;
     myM *= m;
   }
 
-  // modulus m MUST BE coprime to all previous moduli;
-  // CoprimeFlag check disables the coprimeness safety check (to save time)
   void CRTMill::myAddInfo(const BigInt& r, const BigInt& m, CoprimeFlag check)
   {
     if (m < 2)  CoCoA_THROW_ERROR1(ERR::BadModulus);
@@ -71,7 +70,7 @@ namespace CoCoA
       CoCoA_THROW_ERROR2(ERR::BadArg, "new modulus not coprime");
     CoCoA_ASSERT(IsCoprime(m,myM));
     const BigInt a = myR%m;
-    const BigInt k = SymmRemainder(SymmRemainder(r-a,m)*InvMod(myM,m), m);
+    const BigInt k = SymmRemainder(LeastNNegRemainder(r-a,m)*InvMod(myM,m), m);
     myR += k*myM;
     myM *= m;
   }

--- a/src/tests/test-NumTheory4.C
+++ b/src/tests/test-NumTheory4.C
@@ -20,9 +20,11 @@
 #include "CoCoA/GlobalManager.H"
 #include "CoCoA/error.H"
 #include "CoCoA/BigIntOps.H"
+#include "CoCoA/BigRatOps.H"
 #include "CoCoA/NumTheory-CRT.H"
 #include "CoCoA/NumTheory-prime.H"
 #include "CoCoA/NumTheory-CoprimeFactorBasis.H"
+#include "CoCoA/NumTheory-RatReconstruct.H"
 #include "CoCoA/utils.H"
 
 #include <iostream>
@@ -95,6 +97,24 @@ namespace CoCoA
   }
   
 
+  void test_RatReconstruct()
+  {
+    // Taken from an old email (2024-09-24)
+    const BigInt m(536870923);
+    const BigInt r = BigIntFromString("-133938711504058062521343586503804797493927382774057437847102718821399120752284154595014137517805073862154012246567574121259948634520322906545919708367827740890559457959928206211377205431569213484206966838991149");
+
+    RatReconstructByContFrac RatRecon1;
+    RatRecon1.myAddInfo(r,m);
+    CoCoA_ASSERT_ALWAYS(!IsConvincing(RatRecon1));
+
+    RatReconstructByContFrac RatRecon2;
+    RatRecon2.myAddInfo(r,m*m);
+    CoCoA_ASSERT_ALWAYS(IsConvincing(RatRecon2));
+    CoCoA_ASSERT_ALWAYS(ReconstructedRat(RatRecon2) == BigRat(1,27));
+    CoCoA_ASSERT_ALWAYS(IsOne(BadMFactor(RatRecon2)));
+}
+  
+
   void program()
   {
     GlobalManager CoCoAFoundations;
@@ -102,6 +122,7 @@ namespace CoCoA
     test_eratosthenes();
     test_CFB();
     test_CRT();
+    test_RatReconstruct();
   }
 
 } // end of namespace CoCoA

--- a/src/tests/test-NumTheory4.C
+++ b/src/tests/test-NumTheory4.C
@@ -78,12 +78,15 @@ namespace CoCoA
   // Test for CRTMill (very simple test)
   void test_CRT()
   {
-    // Copied from ex-NumTheory2.C
-    const BigInt N = power(10,100);
-    const BigInt UPB = 2*N+1;
+    const BigInt N = -power(10,100);
+    const BigInt UPB = 2*abs(N)+1;
 
     CRTMill crt;
-    int p = 101;
+    // Just a quick check that modulus 1 is disallowed:
+    try { crt.myAddInfo(0,1); CoCoA_ASSERT_ALWAYS(!"Never get here"); }
+    catch (const ErrorInfo& err) { if (err != ERR::BadModulus)  throw; }
+
+    long p = 101;
     while (true)
     {
       p = NextPrime(p);
@@ -101,7 +104,7 @@ namespace CoCoA
   {
     // Taken from an old email (2024-09-24)
     const BigInt m(536870923);
-    const BigInt r = BigIntFromString("-133938711504058062521343586503804797493927382774057437847102718821399120752284154595014137517805073862154012246567574121259948634520322906545919708367827740890559457959928206211377205431569213484206966838991149");
+    const BigInt r = BigIntFromString("-57312042378620423056674247");
 
     RatReconstructByContFrac RatRecon1;
     RatRecon1.myAddInfo(r,m);


### PR DESCRIPTION
Allow non-reduced residues in calls to `RatReconstructByContFrac::myAddInfo`
Previously they were forbidden, but only in DEBUG mode.
I have put in a new test too.